### PR TITLE
Optional sorting

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -56,6 +56,7 @@ export default class Choices {
             search: true,
             flip: true,
             regexFilter: null,
+            shouldSort: true,
             sortFilter: sortByAlpha,
             sortFields: ['label', 'value'],
             placeholder: true,
@@ -886,7 +887,6 @@ export default class Choices {
                             include: 'score',
                         });
                         const results = fuse.search(needle);
-
                         this.currentValue = newValue;
                         this.highlightPosition = 0;
                         this.isSearching = true;
@@ -1880,6 +1880,7 @@ export default class Choices {
                 const passedOptions = Array.from(this.passedElement.options);
                 const allChoices = [];
 
+
                 // Create array of options from option elements
                 passedOptions.forEach((o) => {
                     allChoices.push({
@@ -1959,10 +1960,12 @@ export default class Choices {
     renderChoices(choices, fragment) {
         // Create a fragment to store our list items (so we don't have to update the DOM for each item)
         const choicesFragment = fragment || document.createDocumentFragment();
-        const filter = this.isSearching ? sortByScore : this.config.sortFilter;
 
+        if (this.config.shouldSort || this.isSearching) {
+            const filter = this.isSearching ? sortByScore : this.config.sortFilter;
+            choices.sort(filter);
+        }
         choices
-            .sort(filter)
             .forEach((choice) => {
                 const dropdownItem = this._getTemplate('choice', choice);
                 if (this.passedElement.type === 'select-one') {

--- a/tests/spec/choices_spec.js
+++ b/tests/spec/choices_spec.js
@@ -59,6 +59,7 @@ describe('Choices', function() {
             expect(this.choices.config.regexFilter).toEqual(null);
             expect(this.choices.config.sortFilter).toEqual(jasmine.any(Function));
             expect(this.choices.config.sortFields).toEqual(jasmine.any(Array) || jasmine.any(String));
+            expect(this.choices.config.shouldSort).toEqual(jasmine.any(Boolean));
             expect(this.choices.config.placeholder).toEqual(jasmine.any(Boolean));
             expect(this.choices.config.placeholderValue).toEqual(null);
             expect(this.choices.config.prependValue).toEqual(null);


### PR DESCRIPTION
When using Choices as an alternative for those pesky select tags, sorting select's options is not really the feature I'm looking for. This PR allows user to turn the sorting off completely (leaving it on when search is performed).

I have tried other methods of preventing the sorting from happening, without success. See: http://stackoverflow.com/questions/39249946/javascript-bypassing-sort-attempt-yielded-weird-behaviour#39250125