### PR TITLE
Shorten list style declaration

### DIFF
--- a/assets/styles/scss/choices.scss
+++ b/assets/styles/scss/choices.scss
@@ -135,7 +135,7 @@ $choices-button-offset: 8px !default;
 .#{$choices-selector}__list {
   margin: 0;
   padding-left: 0;
-  list-style-type: none;
+  list-style: none;
 }
 
 .#{$choices-selector}__list--single {


### PR DESCRIPTION
According to http://stackoverflow.com/questions/19889069/whats-the-difference-between-list-style-type-and-list-style `list-style` can be substituted for `list-style-type` if it's meant to replace all relevant sub-styles (position and image).