### PR TITLE
Fix item selection against manual input

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -408,7 +408,6 @@ class Choices {
             // If we actually have anything to add to our dropdown
             // append it and highlight the first choice
             this.choiceList.appendChild(choiceListFragment);
-            this._highlightChoice();
           } else {
             const activeItems = this.store.getItemsFilteredByActive();
             const canAddItem = this._canAddItem(activeItems, this.input.value);
@@ -995,9 +994,9 @@ class Choices {
 
       if (canAddItem.response) {
         this._addItem(choice.value, choice.label, choice.id, choice.groupId);
-        this._triggerChange(choice.value);
       }
     }
+    this._triggerChange(choice.value);
 
     this.clearInput(this.passedElement);
 
@@ -1321,6 +1320,22 @@ class Choices {
     };
 
     const onEnterKey = () => {
+
+      if (hasActiveDropdown) {
+        const highlighted = this.dropdown.querySelector(`.${this.config.classNames.highlightedState}`);
+
+        // If we have a highlighted choice
+        if (highlighted) {
+          this._handleChoiceAction(activeItems, highlighted);
+        }
+      } else if (passedElementType === 'select-one') {
+        // Open single select dropdown if it's not active
+        if (!hasActiveDropdown) {
+          this.showDropdown(true);
+          e.preventDefault();
+        }
+      }
+
       // If enter key is pressed and the input has a value
       if (target.value) {
         const value = this.input.value;
@@ -1347,21 +1362,6 @@ class Choices {
       if (target.hasAttribute('data-button')) {
         this._handleButtonAction(activeItems, target);
         e.preventDefault();
-      }
-
-      if (hasActiveDropdown) {
-        const highlighted = this.dropdown.querySelector(`.${this.config.classNames.highlightedState}`);
-
-        // If we have a highlighted choice
-        if (highlighted) {
-          this._handleChoiceAction(activeItems, highlighted);
-        }
-      } else if (passedElementType === 'select-one') {
-        // Open single select dropdown if it's not active
-        if (!hasActiveDropdown) {
-          this.showDropdown(true);
-          e.preventDefault();
-        }
       }
     };
 

--- a/tests/spec/choices_spec.js
+++ b/tests/spec/choices_spec.js
@@ -265,7 +265,7 @@ describe('Choices', () => {
       this.choices = new Choices(this.input);
       this.choices.input.focus();
 
-      for (var i = 0; i < 2; i++) {
+      for (var i = 0; i < 3; i++) {
         // Key down to third choice
         this.choices._onKeyDown({
           target: this.choices.input,
@@ -297,7 +297,7 @@ describe('Choices', () => {
         ctrlKey: false
       });
 
-      expect(this.choices.currentState.items.length).toBe(2);
+      expect(this.choices.currentState.items.length).toBe(1);
     });
 
     it('should trigger a change callback on selection', function() {


### PR DESCRIPTION
Your prototype was working fine except for two issues :

- The automatic highlight of the first list option is conflicting with user input
- Selecting an option with Enter caused adding the current user input (For instance if I input "foo" and the list shows "foobar" and then I hit direction keys to select "foobar" and hit Enter, it would cause to add "foo" as a new item)

I fixed them both in this PR by:
- Making it so the first option is not highlighted by default
- Reversing the order of detecting the onEnter worklow: First we check for highlighted options and only after the user input.

This should fix (https://github.com/jshjohnson/Choices/issues/39)