### PR TITLE
Allow empty values (#92)

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -1940,7 +1940,7 @@ class Choices {
    * @private
    */
   _addChoice(isSelected, isDisabled, value, label, groupId = -1) {
-    if (!value) return;
+    if (typeof value === 'undefined' || value === null) return;
 
     // Generate unique id
     const choices = this.store.getChoices();

--- a/tests/spec/choices_spec.js
+++ b/tests/spec/choices_spec.js
@@ -640,6 +640,21 @@ describe('Choices', () => {
       expect(choices[choices.length - 2].value).toEqual('Child Five');
     });
 
+    it('should handle setChoices() with blank values', function() {
+      this.choices.setChoices([{
+        label: 'Choice one',
+        value: 'one'
+      }, {
+        label: 'Choice two',
+        value: ''
+      }], 'value', 'label', true);
+
+
+      const choices = this.choices.currentState.choices;
+      expect(choices[0].value).toEqual('one');
+      expect(choices[1].value).toEqual('');
+    });
+
     it('should handle clearStore()', function() {
       this.choices.clearStore();
 


### PR DESCRIPTION
This allows blank string values, such as:

```html
<select name="country">
  <option value="US">United States</option>
  <option value="CA">Canada</option>
  <option value="">None of the above</option>
</select>
```