### PR TITLE
JSON Syntax error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests",
+    "tests"
   ],
   "keywords": [
     "customisable",


### PR DESCRIPTION
There is a syntax error in bower.json. This causes the package not to install using at least the Windows version of bower, and it complains about the error in both VIM and jsonlint.

jsonlint bower.json 
bower.json: Parse error on line 19:
...st",    "tests",  ],  "keywords": [ 
--------------------^
Expected one of: 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[' - It appears you have an extra trailing comma