### PR TITLE
Fix choices.css crash with wicked_pdf

### DIFF
--- a/assets/styles/scss/choices.scss
+++ b/assets/styles/scss/choices.scss
@@ -17,7 +17,7 @@ $choices-keyline-color: #DDDDDD !default;
 $choices-primary-color: #00BCD4 !default;
 $choices-disabled-color: #eaeaea !default;
 $choices-highlight-color: $choices-primary-color !default;
-$choices-button-icon-path: '../../icons/' !default;
+$choices-button-icon-path: '../../icons' !default;
 $choices-button-dimension: 8px !default;
 $choices-button-offset: 8px !default;
 


### PR DESCRIPTION
Okay, this is a WEIRD bug, work with me here for a moment :)

We're using https://github.com/mileszs/wicked_pdf and found that it crashes when we're using choices.js's CSS. The offending lines look like these:

```
assets/styles/css/choices.css
49:  background-image: url("../../icons//cross-inverse.svg");
116:  background-image: url("../../icons//cross.svg");
```

It turns out the double-slash causes wicked_pdf to die. This is relevant to https://github.com/mileszs/wicked_pdf/issues/470 - it's the same error, but the issue there didn't point this out.

Anyway, here's the fix