### PR TITLE
Fix/dropdown height

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -635,7 +635,7 @@ class Choices {
     this.dropdown.setAttribute('aria-expanded', 'true');
 
     const dimensions = this.dropdown.getBoundingClientRect();
-    const dropdownPos = Math.ceil(dimensions.top + window.scrollY + dimensions.height);
+    const dropdownPos = Math.ceil(dimensions.top + window.scrollY + this.dropdown.offsetHeight);
 
     // If flip is enabled and the dropdown bottom position is greater than the window height flip the dropdown.
     let shouldFlip = false;

--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -647,8 +647,6 @@ class Choices {
 
     if (shouldFlip) {
       this.containerOuter.classList.add(this.config.classNames.flippedState);
-    } else {
-      this.containerOuter.classList.remove(this.config.classNames.flippedState);
     }
 
     // Optionally focus the input if we have a search input


### PR DESCRIPTION
* If you use css transition on dropdown, like scale, `getBoundingClientRect.height` value is scaled. So `offsetHeight` gives accurate height value.
* Do not remove `flippedState` class if `shouldFlip !== true`. This class can be added manually before and should stayed there.