### PR TITLE
Fix dropdown hiding on blur in IE11

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -1271,6 +1271,7 @@ class Choices {
     document.addEventListener('touchend', this._onTouchEnd);
     document.addEventListener('mousedown', this._onMouseDown);
     document.addEventListener('mouseover', this._onMouseOver);
+    document.addEventListener('focus', this._onDocumentFocus);
 
     if (this.passedElement.type && this.passedElement.type === 'select-one') {
       this.containerOuter.addEventListener('focus', this._onFocus);
@@ -1296,6 +1297,7 @@ class Choices {
     document.removeEventListener('touchend', this._onTouchEnd);
     document.removeEventListener('mousedown', this._onMouseDown);
     document.removeEventListener('mouseover', this._onMouseOver);
+    document.removeEventListener('focus', this._onDocumentFocus);
 
     if (this.passedElement.type && this.passedElement.type === 'select-one') {
       this.containerOuter.removeEventListener('focus', this._onFocus);
@@ -1690,6 +1692,43 @@ class Choices {
   }
 
   /**
+   * Focus event on everything in the document
+   * @param  {Object} e Event
+   * @return
+   * @private
+   */
+  _onDocumentFocus (e) {
+    const target = e.target;
+    const hasActiveDropdown = this.dropdown.classList.contains(this.config.classNames.activeState);
+
+    const blurActions = {
+      text: () => {
+        if (target !== this.input) {
+          if (hasActiveDropdown) {
+            this.hideDropdown();
+          }
+        }
+      },
+      'select-one': () => {
+        if (target !== this.containerOuter) {
+          if (hasActiveDropdown && !this.canSearch) {
+            this.hideDropdown();
+          }
+        }
+      },
+      'select-multiple': () => {
+        if (target !== this.input) {
+          if (hasActiveDropdown) {
+            this.hideDropdown();
+          }
+        }
+      },
+    };
+
+    blurActions[this.passedElement.type]();
+  }
+
+  /**
    * Paste event
    * @param  {Object} e Event
    * @return
@@ -1767,10 +1806,6 @@ class Choices {
             if (hasHighlightedItems) {
               this.unhighlightAll();
             }
-            // Hide dropdown if it is showing
-            if (hasActiveDropdown) {
-              this.hideDropdown();
-            }
           }
         },
         'select-one': () => {
@@ -1781,21 +1816,11 @@ class Choices {
               this.hideDropdown();
             }
           }
-
-          if (target === this.input) {
-            // Hide dropdown if it is showing
-            if (hasActiveDropdown) {
-              this.hideDropdown();
-            }
-          }
         },
         'select-multiple': () => {
           if (target === this.input) {
             // Remove the focus state
             this.containerOuter.classList.remove(this.config.classNames.focusState);
-            if (hasActiveDropdown) {
-              this.hideDropdown();
-            }
             // De-select any highlighted items
             if (hasHighlightedItems) {
               this.unhighlightAll();


### PR DESCRIPTION
Fixes an issue where clicking on a dropdown scrollbar will close that dropdown in MSIE 11.

## Steps to reproduce

Make a Choices instance of `select-one` type, with a search bar, with enough items to have a search bar in the dropdown.

![image](https://cloud.githubusercontent.com/assets/74385/26102039/f479815a-3a65-11e7-909c-f8efef2950fc.png)

When you click on the scrollbar in IE, it will close the dropdown because it fires the `blur` event on the text field.

## Fix

This closes the dropdown when something else in the document receives a focus (`document.addEventListener('focus', ...)`), INSTEAD of when the text field is blurred.