### PR TITLE
Refocus outer container when dropdown is closed via escape key

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -1469,6 +1469,7 @@ class Choices {
     const onEscapeKey = () => {
       if (hasActiveDropdown) {
         this.toggleDropdown();
+        this.containerOuter.focus();
       }
     };
 


### PR DESCRIPTION
Currently when an escape key press closes the dropdown the search input is blurred but another element is not explicitly given focus so no outline is visible on the outer container. It's still possible to tab to next element, reopen dropdown on keydown, etc, though.

This PR explicitly gives the outer container focus so the widget acts more like to the native select tag.

Is that the best place to put the `focus()`?