### PR TITLE
Fix extra parameter in call to _addItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ example.setValueByChoice('Two'); // Choice with value of 'Two' has now been sele
 ### disable();
 **Input types affected:** `text`, `select-one`, `select-multiple`
 
-**Usage:** Disables input from accepting new value/sselecting further choices.
+**Usage:** Disables input from accepting new value/selecting further choices.
 
 ### enable();
 **Input types affected:** `text`, `select-one`, `select-multiple`

--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -2205,7 +2205,6 @@ class Choices {
         choiceLabel,
         choiceId,
         undefined,
-        undefined,
         customProperties
       );
     }
@@ -2254,7 +2253,8 @@ class Choices {
           label,
           option.selected,
           isOptDisabled,
-          groupId
+          groupId,
+          option.customProperties
         );
       });
     } else {

--- a/tests/spec/choices_spec.js
+++ b/tests/spec/choices_spec.js
@@ -1038,5 +1038,23 @@ describe('Choices', () => {
       expect(selectedItems.length).toBe(1);
       expect(selectedItems[0].customProperties).toBe(expectedCustomProperties);
     });
+
+    it('should allow the user to supply custom properties when directly creating a selected item', function() {
+      const expectedCustomProperties = {
+        isBestOptionEver: true
+      };
+
+      this.choices = new Choices(this.input);
+
+      this.choices.setValue([{
+          value: 'bar',
+          label: 'foo',
+          customProperties: expectedCustomProperties
+      }]);
+      const selectedItems = this.choices.getValue();
+
+      expect(selectedItems.length).toBe(1);
+      expect(selectedItems[0].customProperties).toBe(expectedCustomProperties);
+    });
   });
 });


### PR DESCRIPTION
I introduced one parameter too much in a call to _addItem from _addChoice (here: 0b3cf1a#diff-27edd04b91c69d5ee4cfac4012766ef7R2202) so the former doesn't get the custom properties and can't set them in the newly created item.

Related to issue https://github.com/jshjohnson/Choices/issues/196