### PR TITLE
Add MDN's Object.assign polyfill to the ones imported by the choices library

### DIFF
--- a/assets/scripts/src/lib/polyfills.js
+++ b/assets/scripts/src/lib/polyfills.js
@@ -126,4 +126,30 @@
   CustomEvent.prototype = window.Event.prototype;
 
   window.CustomEvent = CustomEvent;
+
+  // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
+  if (typeof Object.assign != 'function') {
+    Object.assign = function(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    };
+  }
 })();


### PR DESCRIPTION
Problem: Object.assign is not available in IE and older browsers 

Solution: Add polyfill from MDN

Fixes https://github.com/jshjohnson/Choices/issues/213