### PR TITLE
Add aria-activedescendant attribute only when dropdown is active

### DIFF
--- a/assets/scripts/src/choices.js
+++ b/assets/scripts/src/choices.js
@@ -797,6 +797,10 @@ class Choices {
     this.containerOuter.setAttribute('aria-expanded', 'false');
     this.dropdown.classList.remove(this.config.classNames.activeState);
     this.dropdown.setAttribute('aria-expanded', 'false');
+    // IE11 ignores aria-label and blocks virtual keyboard
+    // if aria-activedescendant is set without a dropdown
+    this.input.removeAttribute('aria-activedescendant');
+    this.containerOuter.removeAttribute('aria-activedescendant');
 
     if (isFlipped) {
       this.containerOuter.classList.remove(this.config.classNames.flippedState);
@@ -2198,7 +2202,16 @@ class Choices {
       // Highlight given option, and set accessiblity attributes
       passedEl.classList.add(this.config.classNames.highlightedState);
       passedEl.setAttribute('aria-selected', 'true');
-      this.containerOuter.setAttribute('aria-activedescendant', passedEl.id);
+
+      const hasActiveDropdown = this.dropdown.classList.contains(
+        this.config.classNames.activeState
+      );
+      if (hasActiveDropdown) {
+        // IE11 ignores aria-label and blocks virtual keyboard
+        // if aria-activedescendant is set without a dropdown
+        this.input.setAttribute('aria-activedescendant', passedEl.id);
+        this.containerOuter.setAttribute('aria-activedescendant', passedEl.id);
+      }
     }
   }
 


### PR DESCRIPTION
Add `aria-activedescendant` attribute only when an item is highlighted and the dropdown is active + remove it when the dropdown closes.

The attribute (when set on the `input`) originally prevented virtual keyboard from appearing on tablets with IE11 (5eac8d4)

Adding the attribute conditionally (and removing it as soon as dropdown closes) resolves the problem with virtual keyboard in IE11 (tested on a Surface with IE11) while still keeping the required links for screen readers.