### PR TITLE
Resolved performance problems with large datasets.

### DIFF
--- a/src/scripts/src/choices.js
+++ b/src/scripts/src/choices.js
@@ -70,6 +70,7 @@ class Choices {
     this.currentState = {};
     this.prevState = {};
     this.currentValue = '';
+    this.renderDebounce = null;
 
     // Retrieve triggering element (i.e. element with 'data-choice' trigger)
     const passedElement = isType('String', element) ? document.querySelector(element) : element;
@@ -423,11 +424,22 @@ class Choices {
   }
 
   /**
+   * Render DOM with values.
+   */
+  render() {
+    if (this.renderDebounce) {
+      clearTimeout(this.renderDebounce);
+    }
+
+    this.renderDebounce = setTimeout(() => this._render(), 100);
+  }
+
+  /**
    * Render DOM with values
    * @return
    * @private
    */
-  render() {
+  _render() {
     this.currentState = this.store.getState();
     const stateChanged = (
       this.currentState.choices !== this.prevState.choices ||


### PR DESCRIPTION
I noticed that with large datasets, this library breaks down really bad. After some investigation, I realized that you are "re"-rendering the entire list for EVERY item that is added to the list. This creates a runaway exponential time to render for each new item that is added to the list.

The solution is simple. Add a debounce around the render() method and performance goes up about 10x for large datasets (> 1000 records).

[JSFiddle Before Fix](https://jsfiddle.net/travistidwell/2y03uw13/)  ~1600 records takes more than 30 seconds to render

[JSFiddle After Fix](https://jsfiddle.net/travistidwell/mejrLpu4/)  ~1600 records takes about 2 seconds