### PR TITLE
Add ability to configure the item comparer function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Or include Choices directly:
     maxItemText: (maxItemCount) => {
       return `Only ${maxItemCount} values can be added.`;
     },
+    itemComparer: (choice, item) => {
+      return choice === item;
+    },
     classNames: {
       containerOuter: 'choices',
       containerInner: 'choices__inner',
@@ -457,6 +460,13 @@ const example = new Choices(element, {
 **Input types affected:** `text`
 
 **Usage:** The text that is shown when a user has focus on the input but has already reached the [max item count](https://github.com/jshjohnson/Choices#maxitemcount). To access the max item count, pass a function with a `maxItemCount` argument (see the [default config](https://github.com/jshjohnson/Choices#setup) for an example), otherwise pass a string.
+
+### itemComparer
+**Type:** `Function` **Default:** `strict equality`
+
+**Input types affected:** `select-one`, `select-multiple`
+
+**Usage:** Compare choice and value in appropriate way (e.g. deep equality for objects). To compare choice and value, pass a function with a `itemComparer` argument (see the [default config](https://github.com/jshjohnson/Choices#setup) for an example).
 
 ### classNames
 **Type:** `Object` **Default:**

--- a/src/scripts/src/choices.js
+++ b/src/scripts/src/choices.js
@@ -2369,7 +2369,7 @@ class Choices {
   _findAndSelectChoiceByValue(val) {
     const choices = this.store.getChoices();
     // Check 'value' property exists and the choice isn't already selected
-    const foundChoice = choices.find(choice => choice.value === val);
+    const foundChoice = choices.find(choice => this.config.itemComparer(choice.value, val));
 
     if (foundChoice && !foundChoice.selected) {
       this._addItem(

--- a/src/scripts/src/constants.js
+++ b/src/scripts/src/constants.js
@@ -64,6 +64,7 @@ export const DEFAULT_CONFIG = {
   uniqueItemText: 'Only unique values can be added.',
   addItemText: value => `Press Enter to add <b>"${value}"</b>`,
   maxItemText: maxItemCount => `Only ${maxItemCount} values can be added.`,
+  itemComparer: (choice, item) => (choice === item),
   fuseOptions: {
     includeScore: true,
   },


### PR DESCRIPTION
We need the ability to configure the item comparer using something like [Lodash.isEqual](https://lodash.com/docs/4.17.4#isEqual). With this, we can do the following...

```js
import _isEqual from 'lodash/isEqual';
...
...
let choices = new Choices(...., {
  itemComparer: _isEqual
});
```