### PR TITLE
Update demo URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ Choices is compiled using [Babel](https://babeljs.io/) to enable support for [ES
 **Polyfill example used for the demo:**
 
 ```html
-<script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,fetch,Element.prototype.classList,requestAnimationFrame,Node.insertBefore,Node.firstChild"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.js?features=es5,fetch,Element.prototype.classList,requestAnimationFrame,Node.insertBefore,Node.firstChild,Object.assign"></script>
 ```
 
 **Features used in Choices:**


### PR DESCRIPTION
This is the URL used at the live demo. This change is needed for IE11 support.