### PR TITLE
Correct type for 'callbackOnCreateTemplates'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -715,7 +715,7 @@ declare module "choices.js" {
 			 *
 			 * @default null
 			 */
-      callbackOnCreateTemplates?: (template: string) => string;
+      callbackOnCreateTemplates?: (template: Function) => any;
     }
   }
 


### PR DESCRIPTION
Change from:
```callbackOnCreateTemplates?: (template: Function) => any;```
to:
```callbackOnCreateTemplates?: (template: string) => string;```

Fixes #436 