### PR TITLE
Add the "files" section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
   },
   "author": "Josh Johnson",
   "license": "MIT",
+  "files": [
+    "public/assets/scripts",
+    "public/assets/styles",
+    "src",
+    "types"
+  ],
   "bugs": {
     "url": "https://github.com/jshjohnson/Choices/issues"
   },


### PR DESCRIPTION
No need for publishing images, HTML files and other useless files in npm dist. After merging this PR only these files will remain:

<img src="https://user-images.githubusercontent.com/6059356/48967686-17c6eb00-efed-11e8-8025-88cd2e268b67.png" width="200">

The `public/assest/images` folder will be also excluded from npm package, that's a bad idea to have all those useless for end-users kilobytes in npm.

Read more: https://docs.npmjs.com/files/package.json#files

---

I wish "tech leads" in the JS community would care about the published bundles :)

![image](https://user-images.githubusercontent.com/6059356/47900780-ce203000-de86-11e8-97d1-74e829b1b935.png)
