### PR TITLE
Fixes jshjohnson/Choices/#447

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,11 +385,11 @@ const example = new Choices(element, {
 
 **Usage:** Whether the input should show a placeholder. Used in conjunction with `placeholderValue`. If `placeholder` is set to true and no value is passed to `placeholderValue`, the passed input's placeholder attribute will be used as the  placeholder value.
 
-**Note:** For single select boxes, the recommended way of adding a placeholder is as follows:
+**Note:** For single select boxes, the placeholder will be the option element with an empty value, as per W3C recommendation:
 
 ```html
 <select>
-  <option placeholder>This is a placeholder</option>
+  <option value="">This is a placeholder</option>
   <option>...</option>
   <option>...</option>
   <option>...</option>

--- a/src/scripts/components/wrapped-select.js
+++ b/src/scripts/components/wrapped-select.js
@@ -7,7 +7,7 @@ export default class WrappedSelect extends WrappedElement {
   }
 
   get placeholderOption() {
-    return this.element.querySelector('option[placeholder]');
+    return this.element.querySelector('option[value=""]');
   }
 
   get optionGroups() {

--- a/src/scripts/components/wrapped-select.test.js
+++ b/src/scripts/components/wrapped-select.test.js
@@ -11,14 +11,15 @@ describe('components/wrappedSelect', () => {
   beforeEach(() => {
     element = document.createElement('select');
     element.id = 'target';
-    for (let i = 1; i <= 4; i++) {
+    for (let i = 0; i <= 4; i++) {
       const option = document.createElement('option');
 
-      option.value = `Value ${i}`;
-      option.innerHTML = `Label ${i}`;
-
-      if (i === 1) {
-        option.setAttribute('placeholder', '');
+      if (i > 0) {
+        option.value = `Value ${i}`;
+        option.innerHTML = `Label ${i}`;
+      } else {
+        option.value = '';
+        option.innerHTML = 'Placeholder label';
       }
 
       element.appendChild(option);
@@ -67,7 +68,7 @@ describe('components/wrappedSelect', () => {
   });
 
   describe('placeholderOption getter', () => {
-    it('returns option element with placeholder attribute', () => {
+    it('returns option element with empty value attribute', () => {
       expect(instance.placeholderOption).to.be.instanceOf(HTMLOptionElement);
     });
   });
@@ -142,7 +143,7 @@ describe('components/wrappedSelect', () => {
   describe('appendDocFragment', () => {
     it('empties contents of element', () => {
       expect(instance.element.getElementsByTagName('option').length).to.equal(
-        4,
+        5,
       );
       instance.appendDocFragment(document.createDocumentFragment());
       expect(instance.element.getElementsByTagName('option').length).to.equal(


### PR DESCRIPTION
## This is the problem:
Current implementation forces invalid HTML by requiring use of placeholder attribute on an option element to make it act as placeholder.

## Steps to reproduce:
Run HTML validation of current recommended manner of implementing single select box.

## This is my solution:
Change placeholderOption so that it uses the option element that has an empty value attribute as the placeholder, as [per W3C recommendation](https://www.w3.org/TR/html52/sec-forms.html#the-select-element):

> If a select element has a required attribute specified, does not have a multiple attribute specified, and has a display size of 1; and if the value of the first option element in the select element’s list of options (if any) is the empty string, and that option element’s parent node is the select element (and not an optgroup element), then that option is the select element’s placeholder label option.