### PR TITLE
callback to filter items before adding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ will be returned. If you target one element, that instance will be returned.
     position: 'auto',
     resetScrollPosition: true,
     regexFilter: null,
-    callbackFilterAddItem: null,
+    addItemFilter: null,
     shouldSort: true,
     shouldSortItems: false,
     sortFn: () => {...},
@@ -340,7 +340,7 @@ Pass an array of objects:
 
 **Usage:** Whether the scroll position should reset after adding an item.
 
-### callbackFilterAddItem
+### addItemFilter
 **Type:** `Function` **Default:** `null`
 
 **Input types affected:** `text`
@@ -352,7 +352,7 @@ Pass an array of objects:
 ```js
 // Only adds items matching the text test
 new Choices(element, {
-  callbackFilterAddItem: function (value) {
+  addItemFilter: function (value) {
     return (value !== 'test')
   }
 });

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ will be returned. If you target one element, that instance will be returned.
     position: 'auto',
     resetScrollPosition: true,
     regexFilter: null,
+    callbackFilterAddItem: null,
     shouldSort: true,
     shouldSortItems: false,
     sortFn: () => {...},
@@ -338,6 +339,24 @@ Pass an array of objects:
 **Input types affected:** `select-multiple`
 
 **Usage:** Whether the scroll position should reset after adding an item.
+
+### callbackFilterAddItem
+**Type:** `Function` **Default:** `null`
+
+**Input types affected:** `text`
+
+**Usage:** A callback function that will need to return `true` for a user to successfully add an item.
+
+**Example:**
+
+```js
+// Only adds items matching the text test
+new Choices(element, {
+  callbackFilterAddItem: function (value) {
+    return (value !== 'test')
+  }
+});
+```
 
 ### regexFilter
 **Type:** `Regex` **Default:** `null`

--- a/cypress/integration/text.spec.js
+++ b/cypress/integration/text.spec.js
@@ -293,6 +293,39 @@ describe('Choices - text element', () => {
       });
     });
 
+    describe('custom add item callback', () => {
+      describe('inputting a value that satisfies the callbackCanAddItem', () => {
+        const input = 'test';
+
+        it('allows me to add choice', () => {
+          cy.get('[data-test-hook=add-item-callback]')
+            .find('.choices__input--cloned')
+            .type(input)
+            .type('{enter}');
+
+          cy.get('[data-test-hook=add-item-callback]')
+            .find('.choices__list--multiple .choices__item')
+            .last()
+            .should($choice => {
+              expect($choice.text().trim()).to.equal(input);
+            });
+        });
+      });
+
+      describe('inputting a value that does not satisfy the callback', () => {
+        it('displays dropdown prompt', () => {
+          cy.get('[data-test-hook=add-item-callback]')
+            .find('.choices__input--cloned')
+            .type(`this is not the allowed text`)
+            .type('{enter}');
+
+          cy.get('[data-test-hook=add-item-callback]')
+            .find('.choices__list--dropdown')
+            .should('not.be.visible');
+        });
+      });
+    });
+
     describe('disabled via attribute', () => {
       it('does not allow me to input data', () => {
         cy.get('[data-test-hook=disabled-via-attr]')

--- a/cypress/integration/text.spec.js
+++ b/cypress/integration/text.spec.js
@@ -294,7 +294,7 @@ describe('Choices - text element', () => {
     });
 
     describe('custom add item callback', () => {
-      describe('inputting a value that satisfies the callbackCanAddItem', () => {
+      describe('inputting a value that satisfies the callbackFilterAddItem', () => {
         const input = 'test';
 
         it('allows me to add choice', () => {

--- a/cypress/integration/text.spec.js
+++ b/cypress/integration/text.spec.js
@@ -294,7 +294,7 @@ describe('Choices - text element', () => {
     });
 
     describe('custom add item callback', () => {
-      describe('inputting a value that satisfies the callbackFilterAddItem', () => {
+      describe('inputting a value that satisfies the addItemFilter', () => {
         const input = 'test';
 
         it('allows me to add choice', () => {

--- a/public/test/text.html
+++ b/public/test/text.html
@@ -126,7 +126,7 @@
         });
 
         new Choices('#choices-add-item-callback', {
-          callbackFilterAddItem: function (value) {
+          addItemFilter: function (value) {
             return (value !== 'test')
           }
         });

--- a/public/test/text.html
+++ b/public/test/text.html
@@ -126,7 +126,7 @@
         });
 
         new Choices('#choices-add-item-callback', {
-          callbackOnAddItem: function (value) {
+          callbackFilterAddItem: function (value) {
             return (value !== 'test')
           }
         });

--- a/public/test/text.html
+++ b/public/test/text.html
@@ -64,6 +64,11 @@
           <input class="form-control" id="choices-adding-items-disabled" type="text">
         </div>
 
+        <div data-test-hook="add-item-callback">
+          <label for="choices-add-item-callback">Callback on Add Item</label>
+          <input class="form-control" id="choices-add-item-callback" type="text">
+        </div>
+
         <div data-test-hook="disabled-via-attr">
           <label for="choices-disabled-via-attr">Disabled via attribute</label>
           <input class="form-control" id="choices-disabled-via-attr" type="text" disabled>
@@ -118,6 +123,12 @@
 
         new Choices('#choices-adding-items-disabled', {
           addItems: false,
+        });
+
+        new Choices('#choices-add-item-callback', {
+          callbackOnAddItem: function (value) {
+            return (value !== 'test')
+          }
         });
 
         new Choices('#choices-disabled-via-attr');

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -973,8 +973,8 @@ class Choices {
       }
 
       if (
-        isType('Function', this.config.callbackFilterAddItem) &&
-        this.config.callbackFilterAddItem(value) &&
+        isType('Function', this.config.addItemFilter) &&
+        this.config.addItemFilter(value) &&
         this._isTextElement &&
         this.config.addItems &&
         canAddItem

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -973,8 +973,8 @@ class Choices {
       }
 
       if (
-        isType('Function', this.config.callbackOnAddItem) &&
-        this.config.callbackOnAddItem(value) &&
+        isType('Function', this.config.callbackFilterAddItem) &&
+        this.config.callbackFilterAddItem(value) &&
         this._isTextElement &&
         this.config.addItems &&
         canAddItem

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -971,6 +971,19 @@ class Choices {
           ? this.config.uniqueItemText(value)
           : this.config.uniqueItemText;
       }
+
+      if (
+        isType('Function', this.config.callbackOnAddItem) &&
+        this.config.callbackOnAddItem(value) &&
+        this._isTextElement &&
+        this.config.addItems &&
+        canAddItem
+      ) {
+        canAddItem = false;
+        notice = isType('Function', this.config.customAddItemText)
+          ? this.config.customAddItemText(value)
+          : this.config.customAddItemText;
+      }
     }
 
     return {

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -72,7 +72,7 @@ export const DEFAULT_CONFIG = {
     includeScore: true,
   },
   callbackOnInit: null,
-  callbackFilterAddItem: null,
+  addItemFilter: null,
   callbackOnCreateTemplates: null,
   classNames: DEFAULT_CLASSNAMES,
 };

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -72,7 +72,7 @@ export const DEFAULT_CONFIG = {
     includeScore: true,
   },
   callbackOnInit: null,
-  callbackCanAddItem: null,
+  callbackFilterAddItem: null,
   callbackOnCreateTemplates: null,
   classNames: DEFAULT_CLASSNAMES,
 };

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -64,6 +64,7 @@ export const DEFAULT_CONFIG = {
   noChoicesText: 'No choices to choose from',
   itemSelectText: 'Press to select',
   uniqueItemText: 'Only unique values can be added',
+  customAddItemText: 'Only values matching specific conditions can be added.',
   addItemText: value => `Press Enter to add <b>"${stripHTML(value)}"</b>`,
   maxItemText: maxItemCount => `Only ${maxItemCount} values can be added`,
   itemComparer: (choice, item) => choice === item,
@@ -71,6 +72,7 @@ export const DEFAULT_CONFIG = {
     includeScore: true,
   },
   callbackOnInit: null,
+  callbackCanAddItem: null,
   callbackOnCreateTemplates: null,
   classNames: DEFAULT_CLASSNAMES,
 };

--- a/src/scripts/constants.test.js
+++ b/src/scripts/constants.test.js
@@ -86,7 +86,7 @@ describe('constants', () => {
         expect(DEFAULT_CONFIG.addItemText).to.be.a('function');
         expect(DEFAULT_CONFIG.maxItemText).to.be.a('function');
         expect(DEFAULT_CONFIG.fuseOptions).to.be.an('object');
-        expect(DEFAULT_CONFIG.callbackFilterAddItem).to.equal(null);
+        expect(DEFAULT_CONFIG.addItemFilter).to.equal(null);
         expect(DEFAULT_CONFIG.callbackOnInit).to.equal(null);
         expect(DEFAULT_CONFIG.callbackOnCreateTemplates).to.equal(null);
       });

--- a/src/scripts/constants.test.js
+++ b/src/scripts/constants.test.js
@@ -86,7 +86,7 @@ describe('constants', () => {
         expect(DEFAULT_CONFIG.addItemText).to.be.a('function');
         expect(DEFAULT_CONFIG.maxItemText).to.be.a('function');
         expect(DEFAULT_CONFIG.fuseOptions).to.be.an('object');
-        expect(DEFAULT_CONFIG.callbackOnAddItem).to.equal(null);
+        expect(DEFAULT_CONFIG.callbackFilterAddItem).to.equal(null);
         expect(DEFAULT_CONFIG.callbackOnInit).to.equal(null);
         expect(DEFAULT_CONFIG.callbackOnCreateTemplates).to.equal(null);
       });

--- a/src/scripts/constants.test.js
+++ b/src/scripts/constants.test.js
@@ -82,9 +82,11 @@ describe('constants', () => {
         expect(DEFAULT_CONFIG.noChoicesText).to.be.a('string');
         expect(DEFAULT_CONFIG.itemSelectText).to.be.a('string');
         expect(DEFAULT_CONFIG.uniqueItemText).to.be.a('string');
+        expect(DEFAULT_CONFIG.customAddItemText).to.be.a('string');
         expect(DEFAULT_CONFIG.addItemText).to.be.a('function');
         expect(DEFAULT_CONFIG.maxItemText).to.be.a('function');
         expect(DEFAULT_CONFIG.fuseOptions).to.be.an('object');
+        expect(DEFAULT_CONFIG.callbackOnAddItem).to.equal(null);
         expect(DEFAULT_CONFIG.callbackOnInit).to.equal(null);
         expect(DEFAULT_CONFIG.callbackOnCreateTemplates).to.equal(null);
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a callback to filter the user adding an item until said condition is met. In the test updates this would be - A text instance will only allow the value `test`. This can be expanded on greatly beyond the limits of what a regex filter only offers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves #483
I found a use case in a project I'm working on where 2 choices instances needed to avoid duplicate keywords items between them. This cannot be solved with regexFilter only feature available right now as the user inputs are dynamic and change on the fly. 

I understand it's probably possible to write an overly complex regex pattern that updates with the `addItem` and `removeItem` event - But this is way more effort than the solution on offer in this PR.

Another use case this would cover is
`regexFilter` covers email validity and `callbackFilterAddItem` checks other values within form to pass this value.

## How Has This Been Tested?
I've copied the current structure and added tests in cypress

Tests passing locally before creating this PR

This will affect Text inputs only.

This is largely a non-breaking change as it's an addition to existing functionality.

Try it yourself like so: 

```javascript
new Choices('#choices-add-item-callback', {
  callbackFilterAddItem: function (value) {
    return (value !== 'test')
  }
});
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.