### PR TITLE
Fixes issue where deepmerge concatenates arrays inside DEFAULT_CONFIG

### DIFF
--- a/cypress/integration/select-multiple.spec.js
+++ b/cypress/integration/select-multiple.spec.js
@@ -853,5 +853,35 @@ describe('Choices - select multiple', () => {
           });
       });
     });
+
+    describe('searching by label only', () => {
+      it('gets zero results when searching by value', () => {
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__input--cloned')
+          .type('value1');
+
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__list--dropdown .choices__list')
+          .children()
+          .first()
+          .should($choice => {
+            expect($choice.text().trim()).to.equal('No results found');
+          });
+      });
+
+      it('gets a result when searching by label', () => {
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__input--cloned')
+          .type('label1');
+
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__list--dropdown .choices__list')
+          .children()
+          .first()
+          .should($choice => {
+            expect($choice.text().trim()).to.equal('label1');
+          });
+      });
+    });
   });
 });

--- a/cypress/integration/select-one.spec.js
+++ b/cypress/integration/select-one.spec.js
@@ -867,5 +867,41 @@ describe('Choices - select one', () => {
           });
       });
     });
+
+    describe('searching by label only', () => {
+      beforeEach(() => {
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices')
+          .click();
+      });
+
+      it('gets zero results when searching by value', () => {
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__input--cloned')
+          .type('value1');
+
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__list--dropdown .choices__list')
+          .children()
+          .first()
+          .should($choice => {
+            expect($choice.text().trim()).to.equal('No results found');
+          });
+      });
+
+      it('gets a result when searching by label', () => {
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__input--cloned')
+          .type('label1');
+
+        cy.get('[data-test-hook=search-by-label]')
+          .find('.choices__list--dropdown .choices__list')
+          .children()
+          .first()
+          .should($choice => {
+            expect($choice.text().trim()).to.equal('label1');
+          });
+      });
+    });
   });
 });

--- a/public/test/select-multiple.html
+++ b/public/test/select-multiple.html
@@ -194,6 +194,14 @@
             <option value="Choice 3">Choice 3</option>
           </select>
         </div>
+
+        <div data-test-hook="search-by-label">
+          <label for="choices-search-by-label">Search by label</label>
+          <select class="form-control" name="choices-search-by-label" id="choices-search-by-label" multiple>
+            <option value="value1">label1</option>
+            <option value="value2">label2</option>
+          </select>
+        </div>
       </div>
     </div>
     <script>
@@ -307,6 +315,8 @@
         new Choices('#choices-within-form');
 
         new Choices('#choices-set-choice-by-value').setChoiceByValue('Choice 2');
+
+        new Choices('#choices-search-by-label', { searchFields: ['label'] });
       });
     </script>
   </body>

--- a/public/test/select-one.html
+++ b/public/test/select-one.html
@@ -198,6 +198,14 @@
             <option value="Choice 3">Choice 3</option>
           </select>
         </div>
+
+        <div data-test-hook="search-by-label">
+          <label for="choices-search-by-label">Search by label</label>
+          <select class="form-control" name="choices-search-by-label" id="choices-search-by-label">
+            <option value="value1">label1</option>
+            <option value="value2">label2</option>
+          </select>
+        </div>
       </div>
     </div>
     <script>
@@ -319,6 +327,8 @@
         new Choices('#choices-within-form');
 
         new Choices('#choices-set-choice-by-value').setChoiceByValue('Choice 2');
+
+        new Choices('#choices-search-by-label', { searchFields: ['label'] });
       });
     </script>
   </body>

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -56,7 +56,12 @@ class Choices {
       }
     }
 
-    this.config = merge.all([DEFAULT_CONFIG, Choices.userDefaults, userConfig]);
+    this.config = merge.all(
+      [DEFAULT_CONFIG, Choices.userDefaults, userConfig],
+      // When merging array configs, replace with a copy of the userConfig array,
+      // instead of concatenating with the default array
+      { arrayMerge: (destinationArray, sourceArray) => [...sourceArray] },
+    );
 
     if (!doKeysMatch(this.config, DEFAULT_CONFIG)) {
       console.warn('Unknown config option(s) passed');


### PR DESCRIPTION
... instead of replacing them.

## Description
provides `deepmerge` with a function to replace its typical array merging behavior with a function that overwrites the destination array with a copy of the source array instead of concatenating the two.
Documentation for that feature here: https://www.npmjs.com/package/deepmerge#arraymerge

## Motivation and Context
Without this fix, the `searchFields` config will *always* have `[ 'label', 'value']` plus whatever config the user passes in, making it impossible to NOT search both `label` and `value`
https://github.com/jshjohnson/Choices/issues/495

## How Has This Been Tested?
Tests included in PR.    Basically, attempt to type `value` entries into the search input, and make sure there are no results.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (i hope)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.