### PR TITLE
fixes the 'invalid input type' check (passedElement)

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -101,7 +101,7 @@ class Choices {
       });
     }
 
-    if (!passedElement) {
+    if (!this.passedElement) {
       return console.error('Passed element was of an invalid type');
     }
 


### PR DESCRIPTION
## Description
in the constructor, the second check for `passedElement` ( https://github.com/jshjohnson/Choices/blob/9c001487bacad7588e92f8b6d54880b88bf21fc6/src/scripts/choices.js#L104 )  should be checking `this.passedElement`, that's what's getting set by the `WrappedInput` or `WrappedSelect`.

## Motivation and Context
If the user makes a mistake, and tries to instantiate `Choices` on a hidden input (a bug in my code caused that to happen), it causes a javascript exception way down the execution path, instead of giving the intended warning.

## How Has This Been Tested?
Manual testing so far.   I tried to write tests in `text.spec.js`, but I am not quite experienced enough with `Cypress` to get to to work, I guess.  I was attempting to use `cy.spy(console, 'error')` to make sure the right console error was raised, but I couldn't seem to get it working - the `expect(spy).to.be.called` always fails.

So maybe this needs some tests added, too, though it's not as critical as my last PR, so i'll let you make the call.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.