### PR TITLE
Make clearChoices public + allow empty array in setChoices

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ choices.disable();
 ### setChoices(choices, value, label, replaceChoices);
 **Input types affected:** `select-one`, `select-multiple`
 
-**Usage:** Set choices of select input via an array of objects, a value name and a label name. This behaves the same as passing items via the `choices` option but can be called after initialising Choices. This can also be used to add groups of choices (see example 2); Optionally pass a true `replaceChoices` value to remove any existing choices. Optionally pass a `customProperties` object to add additional data to your choices (useful when searching/filtering etc).
+**Usage:** Set choices of select input via an array of objects, a value name and a label name. This behaves the same as passing items via the `choices` option but can be called after initialising Choices. This can also be used to add groups of choices (see example 2); Optionally pass a true `replaceChoices` value to remove any existing choices. Optionally pass a `customProperties` object to add additional data to your choices (useful when searching/filtering etc). Passing an empty array as the first parameter, and a true `replaceChoices` is the same as calling `clearChoices` (see below).
 
 **Example 1:**
 
@@ -790,6 +790,11 @@ example.setChoices([{
   ]
 }], 'value', 'label', false);
 ```
+
+### clearChoices();
+**Input types affected:** `select-one`, `select-multiple`
+
+**Usage:** Clear all choices from select
 
 ### getValue(valueOnly)
 **Input types affected:** `text`, `select-one`, `select-multiple`

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -411,7 +411,7 @@ class Choices {
   }
 
   setChoices(choices = [], value = '', label = '', replaceChoices = false) {
-    if (!this._isSelectElement || !choices.length || !value) {
+    if (!this._isSelectElement || !value) {
       return this;
     }
 

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -417,7 +417,7 @@ class Choices {
 
     // Clear choices if needed
     if (replaceChoices) {
-      this._clearChoices();
+      this.clearChoices();
     }
 
     this.containerOuter.removeLoadingState();
@@ -446,6 +446,10 @@ class Choices {
     this._setLoading(false);
 
     return this;
+  }
+
+  clearChoices() {
+    this._store.dispatch(clearChoices());
   }
 
   clearStore() {
@@ -1727,10 +1731,6 @@ class Choices {
         keyCode,
       });
     }
-  }
-
-  _clearChoices() {
-    this._store.dispatch(clearChoices());
   }
 
   _addGroup({ group, id, valueKey = 'value', labelKey = 'label' }) {

--- a/src/scripts/choices.test.js
+++ b/src/scripts/choices.test.js
@@ -1339,14 +1339,14 @@ describe('choices', () => {
         addChoiceStub = stub();
         containerOuterRemoveLoadingStateStub = stub();
 
-        instance._clearChoices = clearChoicesStub;
+        instance.clearChoices = clearChoicesStub;
         instance._addGroup = addGroupStub;
         instance._addChoice = addChoiceStub;
         instance.containerOuter.removeLoadingState = containerOuterRemoveLoadingStateStub;
       });
 
       afterEach(() => {
-        instance._clearChoices.reset();
+        instance.clearChoices.reset();
         instance._addGroup.reset();
         instance._addChoice.reset();
         instance.containerOuter.removeLoadingState.reset();

--- a/src/scripts/choices.test.js
+++ b/src/scripts/choices.test.js
@@ -1370,15 +1370,6 @@ describe('choices', () => {
       });
 
       describe('passing invalid arguments', () => {
-        describe('passing an empty array', () => {
-          beforeEach(() => {
-            instance._isSelectElement = true;
-            instance.setChoices([], value, label, false);
-          });
-
-          returnsEarly();
-        });
-
         describe('passing no value', () => {
           beforeEach(() => {
             instance._isSelectElement = true;
@@ -1426,6 +1417,22 @@ describe('choices', () => {
                 placeholder: choices[index].placeholder,
               });
             });
+          });
+        });
+
+        describe('passing an empty array with a true replaceChoices flag', () => {
+          it('choices are cleared', () => {
+            instance._isSelectElement = true;
+            instance.setChoices([], value, label, true);
+            expect(clearChoicesStub.called).to.equal(true);
+          });
+        });
+
+        describe('passing an empty array with a false replaceChoices flag', () => {
+          it('choices stay the same', () => {
+            instance._isSelectElement = true;
+            instance.setChoices([], value, label, false);
+            expect(clearChoicesStub.called).to.equal(false);
           });
         });
 


### PR DESCRIPTION
## Description
- [x] make the `clearChoices` method public
- [x] passing an empty array to `setChoices` should clear the choices
- [x] update documentation

## Motivation and Context
See #545

## How Has This Been Tested?
I modified the related tests to make them pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.