### PR TITLE
Fix CustomEvent creation in IE9+

### DIFF
--- a/src/scripts/lib/utils.js
+++ b/src/scripts/lib/utils.js
@@ -178,11 +178,17 @@ export const sortByAlpha = (a, b) => {
 export const sortByScore = (a, b) => a.score - b.score;
 
 export const dispatchEvent = (element, type, customArgs = null) => {
-  const event = new CustomEvent(type, {
-    detail: customArgs,
-    bubbles: true,
-    cancelable: true,
-  });
+  let event;
+  try {
+    event = new CustomEvent(type, {
+      detail: customArgs,
+      bubbles: true,
+      cancelable: true,
+    });
+  } catch {
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent(type, true, true, customArgs);
+  }
 
   return element.dispatchEvent(event);
 };


### PR DESCRIPTION
## Description
the [constructor API](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) isn't supported in IE, requiring a polyfill for those environments.

## Motivation and Context
since a simple solution exists -- use the (now-deprecated) [stateful construction API](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent) in IE -- and since CustomEvent creation is highly localized, it seemed trivial to implement.

with this change, modern browsers will use the recommended form while IE will gracefully fall back to the deprecated form.

this should also remove the need to load a polyfill for those browsers.

## How Has This Been Tested?
using CI. it only adds a `try`/`catch` block, so the original code flow is undisturbed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.