### PR TITLE
update type for item function in Template interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ classNames: {
 const example = new Choices(element, {
   callbackOnCreateTemplates: function (template) {
     return {
-      item: (classNames, data) => {
+      item: (classNames, data, removeItemButton) => {
         return template(`
           <div class="${classNames.item} ${data.highlighted ? classNames.highlightedState : classNames.itemSelectable}" data-item data-id="${data.id}" data-value="${data.value}" ${data.active ? 'aria-selected="true"' : ''} ${data.disabled ? 'aria-disabled="true"' : ''}>
             <span>&bigstar;</span> ${data.label}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -116,7 +116,7 @@ declare namespace Choices {
     containerInner?: () => HTMLElement;
     itemList?: () => HTMLElement;
     placeholder?: (value: string) => HTMLElement;
-    item?: (data: any) => HTMLElement;
+    item?: (globalClasses: any, data: any, removeItemButton: boolean) => HTMLElement;
     choiceList?: () => HTMLElement;
     choiceGroup?: (data: any) => HTMLElement;
     choice?: (data: any) => HTMLElement;


### PR DESCRIPTION
## Description
item function in Templace interface accepts three parameters. Current typescript typing only provides one parameter.

## Checklist:
Example in documentation needs to be updated, i added the parameter to the example function