### PR TITLE
Create new options on the fly from user-written values => add a callback for unknown choices

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -1238,6 +1238,8 @@ class Choices {
 
   _onEnterKey({ event, target, activeItems, hasActiveDropdown }) {
     const { ENTER_KEY: enterKey } = KEY_CODES;
+    const hasShiftKey = event.shiftKey;
+    const { callbackOnUnknownChoice } = this.config;
     const targetWasButton = target.hasAttribute('data-button');
 
     if (this._isTextElement && target.value) {
@@ -1262,12 +1264,20 @@ class Choices {
         `.${this.config.classNames.highlightedState}`,
       );
 
-      if (highlightedChoice) {
+      if (hasShiftKey && callbackOnUnknownChoice) {
+        if (isType('Function', callbackOnUnknownChoice)) {
+          callbackOnUnknownChoice.call(this, this.input.value, hasShiftKey);
+        }
+      } else if (highlightedChoice) {
         // add enter keyCode value
         if (activeItems[0]) {
           activeItems[0].keyCode = enterKey; // eslint-disable-line no-param-reassign
         }
         this._handleChoiceAction(activeItems, highlightedChoice);
+      } else if (callbackOnUnknownChoice) {
+        if (isType('Function', callbackOnUnknownChoice)) {
+          callbackOnUnknownChoice.call(this, this.input.value, hasShiftKey);
+        }
       }
 
       event.preventDefault();

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -812,13 +812,13 @@ class Choices {
     this.input.focus();
   }
 
-  _handleChoiceAction(activeItems, element) {
-    if (!activeItems || !element) {
+  _handleChoiceAction(activeItems, element, idDirectly) {
+    if (!activeItems || (!element && !idDirectly)) {
       return;
     }
 
     // If we are clicking on an option
-    const id = element.getAttribute('data-id');
+    const id = idDirectly || element.getAttribute('data-id');
     const choice = this._store.getChoiceById(id);
     const passedKeyCode =
       activeItems[0] && activeItems[0].keyCode ? activeItems[0].keyCode : null;

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -73,6 +73,7 @@ export const DEFAULT_CONFIG = {
   },
   callbackOnInit: null,
   callbackOnCreateTemplates: null,
+  callbackOnUnknownChoice: null,
   classNames: DEFAULT_CLASSNAMES,
 };
 


### PR DESCRIPTION
## Description
Sometimes the user needs to be allowed to add some not-yet-existing options on the fly.

## Motivation and Context
If this library is to allow the user to enter a set of freely-written tags, choices need to be created from the user input on the fly if they don't exist yet.
I guess the motivation is similar to the one for a tagging mode in Select2: https://select2.org/tagging , and related to pull-request #525 "Allow user-created choices for selects". So this addresses #39 as well. (We only discovered those issues after implementing our approach.)

In this implementation here, we provide a callback to be used when the user enters a value not yet available among the existing options, and allow the user to bypass the dropdown consultation entirely by holding the Shift key together with the Enter key. This approach is different from the ones mentioned above.

@caramiki: maybe you'd like to comment / compare?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It works on multiple-value selects in our application. Something like the following callback function can be passed as a configuration option to Choices:
```
    // The following function gets 'this' from Choices ...
    var _this = this;
    const callbackOnUnknownChoice = function(value, hasShift) {
      var choices = this;
      const reject = function() {
        choices.dropdown.isActive = false;
        choices.showDropdown();
        choices.input.focus();
        choices.clearInput();
        return false;
      };
      if (this._store.activeItems.findIndex(x => (x.value.data.text === value)) > -1) {
        alert(`Tag "${value}" already selected!`);
        return reject();
      }
      var idx = this._store.choices.findIndex(x => (x.value.data.text === value));
      if (idx > -1) {
        const item = this._store.choices[idx];
        console.log(`Tag "${value}" already exists: `,item);
        this.highlightItem(item);
        const activeItems = this._store.activeItems;
        if (activeItems[0]) {
          activeItems[0].keyCode = 13;
        }
        // use the new parameter to directly pass the item id:
        this._handleChoiceAction(this._store.activeItems, null, item.id);
        return false;
      }
      if (!hasShift) {
        if (!confirm(`New Tag "${value}" ?`)) {
          return reject();
        }
      }
      const newTagObj = {"<placeholder-to-create-this-object-from>": value}
      const newItem = {
        label: value,
        value: newTagObj,
        keyCode: 13,
        isSelected: true,
        active: false
      };
      //console.log('Adding choice ',newItem);
      this.setChoices([newItem],'value','label',false);
      const idx = this._store.choices.findIndex(x => (x.value.data.text === value));
      if (idx > -1) {
        const item = this._store.choices[idx];
        //console.log('Activating item ',item.id);
        this.highlightItem(item);
        const activeItems = this._store.activeItems;
        if (activeItems[0]) {
          activeItems[0].keyCode = 13;
        }
        this._handleChoiceAction(this._store.activeItems, null, item.id);
      }
      else {
        console.warn('added choice not found: ',value);
      }
      this.clearInput();
      return true;
    };
```
Of course, this uses internal functions...

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.