### PR TITLE
Resolve issue #607 with utils::calcWidthOfInput()

### DIFF
--- a/src/scripts/lib/utils.js
+++ b/src/scripts/lib/utils.js
@@ -140,7 +140,8 @@ export const calcWidthOfInput = (input, callback) => {
         testEl.style.fontStyle = inputStyle.fontStyle;
         testEl.style.letterSpacing = inputStyle.letterSpacing;
         testEl.style.textTransform = inputStyle.textTransform;
-        testEl.style.padding = inputStyle.padding;
+        testEl.style.paddingLeft = inputStyle.paddingLeft;
+        testEl.style.paddingRight = inputStyle.paddingRight;
       }
     }
 


### PR DESCRIPTION
## Description
This change modifies the `utils::calcWidthOfInput()` function to transfer `paddingLeft` and `paddingRight` from the source input to the test input explicitly, rather than relying on the shorthand property `padding`.

## Motivation and Context
See #607 - shorthand CSS properties are not supported in `window.getComputedStyle()` except in Chrome (due to a departure from CSS spec in favor of usability).

This results in width being undercounted in Firefox for inputs that use padding.

## How Has This Been Tested?

Tested in Chrome and Firefox to confirm padding is now accounted for correctly in both.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.