### PR TITLE
fix unhighlightAll performance issue

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -1451,7 +1451,7 @@ class Choices {
         this.hideDropdown();
       }
     } else {
-      const hasHighlightedItems = this._store.highlightedActiveItems;
+      const hasHighlightedItems = this._store.highlightedActiveItems.length > 0;
 
       if (hasHighlightedItems) {
         this.unhighlightAll();


### PR DESCRIPTION
## Description
Due to an error in a condition, hasHighlightedItems variable is assigned an array and the condition below is always true. As a result, unhighlightAll is called each time, which updates items that need to be rendered again.

## Motivation and Context
When using Formio.js with large number of select components performance issue was noticed.
For every click and keypress in any component items of all select components are rendered.

## How Has This Been Tested?
Tested locally in Formio.js
After this fix unhighlightAll and _render are not called on every click

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.