### PR TITLE
use templates from instance, fixes #461

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -101,6 +101,7 @@ class Choices {
       this.passedElement = new WrappedSelect({
         element: passedElement,
         classNames: this.config.classNames,
+        templates: this.config.templates,
       });
     }
 

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -101,7 +101,7 @@ class Choices {
       this.passedElement = new WrappedSelect({
         element: passedElement,
         classNames: this.config.classNames,
-        templates: this.config.templates,
+        template: data => this.config.templates.option(data),
       });
     }
 

--- a/src/scripts/components/wrapped-select.js
+++ b/src/scripts/components/wrapped-select.js
@@ -1,9 +1,9 @@
 import WrappedElement from './wrapped-element';
 
 export default class WrappedSelect extends WrappedElement {
-  constructor({ element, classNames, templates }) {
+  constructor({ element, classNames, template }) {
     super({ element, classNames });
-    this.templates = templates;
+    this.template = template;
   }
 
   get placeholderOption() {
@@ -20,10 +20,9 @@ export default class WrappedSelect extends WrappedElement {
 
   set options(options) {
     const fragment = document.createDocumentFragment();
-    const template = this.templates.option;
     const addOptionToFragment = data => {
       // Create a standard select option
-      const option = template(data);
+      const option = this.template(data);
       // Append it to fragment
       fragment.appendChild(option);
     };

--- a/src/scripts/components/wrapped-select.js
+++ b/src/scripts/components/wrapped-select.js
@@ -1,9 +1,9 @@
 import WrappedElement from './wrapped-element';
-import templates from './../templates';
 
 export default class WrappedSelect extends WrappedElement {
-  constructor({ element, classNames }) {
+  constructor({ element, classNames, templates }) {
     super({ element, classNames });
+    this.templates = templates;
   }
 
   get placeholderOption() {
@@ -22,7 +22,7 @@ export default class WrappedSelect extends WrappedElement {
     const fragment = document.createDocumentFragment();
     const addOptionToFragment = data => {
       // Create a standard select option
-      const template = templates.option(data);
+      const template = this.templates.option(data);
       // Append it to fragment
       fragment.appendChild(template);
     };

--- a/src/scripts/components/wrapped-select.js
+++ b/src/scripts/components/wrapped-select.js
@@ -20,11 +20,12 @@ export default class WrappedSelect extends WrappedElement {
 
   set options(options) {
     const fragment = document.createDocumentFragment();
+    const template = this.templates.option;
     const addOptionToFragment = data => {
       // Create a standard select option
-      const template = this.templates.option(data);
+      const option = template(data);
       // Append it to fragment
-      fragment.appendChild(template);
+      fragment.appendChild(option);
     };
 
     // Add each list item to list

--- a/src/scripts/components/wrapped-select.test.js
+++ b/src/scripts/components/wrapped-select.test.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
-import { stub } from 'sinon';
+import { stub, spy } from 'sinon';
 import WrappedElement from './wrapped-element';
 import WrappedSelect from './wrapped-select';
 import { DEFAULT_CLASSNAMES } from '../constants';
+import TEMPLATES from '../templates';
 
 describe('components/wrappedSelect', () => {
   let instance;
@@ -28,6 +29,9 @@ describe('components/wrappedSelect', () => {
     instance = new WrappedSelect({
       element: document.getElementById('target'),
       classNames: DEFAULT_CLASSNAMES,
+      templates: {
+        option: spy(TEMPLATES.option),
+      },
     });
   });
 
@@ -133,6 +137,7 @@ describe('components/wrappedSelect', () => {
       selectElement.appendChild(fragment);
 
       expect(fragment).to.be.instanceOf(DocumentFragment);
+      expect(instance.templates.option.callCount).to.equal(2);
       expect(selectElement.options.length).to.equal(2);
       expect(selectElement.options[0].value).to.equal(options[0].value);
       expect(selectElement.options[1].value).to.equal(options[1].value);

--- a/src/scripts/components/wrapped-select.test.js
+++ b/src/scripts/components/wrapped-select.test.js
@@ -3,7 +3,7 @@ import { stub, spy } from 'sinon';
 import WrappedElement from './wrapped-element';
 import WrappedSelect from './wrapped-select';
 import { DEFAULT_CLASSNAMES } from '../constants';
-import TEMPLATES from '../templates';
+import Templates from '../templates';
 
 describe('components/wrappedSelect', () => {
   let instance;
@@ -30,7 +30,7 @@ describe('components/wrappedSelect', () => {
       element: document.getElementById('target'),
       classNames: DEFAULT_CLASSNAMES,
       templates: {
-        option: spy(TEMPLATES.option),
+        option: spy(Templates.option),
       },
     });
   });

--- a/src/scripts/components/wrapped-select.test.js
+++ b/src/scripts/components/wrapped-select.test.js
@@ -29,9 +29,7 @@ describe('components/wrappedSelect', () => {
     instance = new WrappedSelect({
       element: document.getElementById('target'),
       classNames: DEFAULT_CLASSNAMES,
-      templates: {
-        option: spy(Templates.option),
-      },
+      template: spy(Templates.option),
     });
   });
 
@@ -137,7 +135,7 @@ describe('components/wrappedSelect', () => {
       selectElement.appendChild(fragment);
 
       expect(fragment).to.be.instanceOf(DocumentFragment);
-      expect(instance.templates.option.callCount).to.equal(2);
+      expect(instance.template.callCount).to.equal(2);
       expect(selectElement.options.length).to.equal(2);
       expect(selectElement.options[0].value).to.equal(options[0].value);
       expect(selectElement.options[1].value).to.equal(options[1].value);


### PR DESCRIPTION
Templates can be overriden by providing `callbackOnCreateTemplates`, that saves merged object in `this.config.templates`. However, while refactoring for 4.x, `WrappedSelect` was hard bounded to original, non user provided callbacks. This PR fixes that also fixes #461. 
