### PR TITLE
Increase Unit test coverage by testing SELECT case

### DIFF
--- a/config/jsdom.js
+++ b/config/jsdom.js
@@ -50,6 +50,7 @@ global.Element = window.Element;
 global.HTMLElement = window.HTMLElement;
 global.HTMLOptionElement = window.HTMLOptionElement;
 global.HTMLOptGroupElement = window.HTMLOptGroupElement;
+global.Option = window.Option;
 global.DocumentFragment = window.DocumentFragment;
 
 copyProps(window, global);

--- a/src/scripts/choices.test.js
+++ b/src/scripts/choices.test.js
@@ -51,6 +51,48 @@ describe('choices', () => {
         });
       });
 
+      describe('init with SELECT element', () => {
+        it('works with empty select and choices array', () => {
+          const select = document.createElement('select');
+          document.body.appendChild(select);
+          const calledValues = [];
+          const choices = new Choices(select, {
+            choices: [
+              {
+                value: 'Option 1 value',
+                label: 'Option 1',
+                selected: false,
+              },
+              {
+                value: 'Option 2 value',
+                label: 'Option 2',
+                selected: true,
+              },
+            ],
+            callbackOnCreateTemplates: () => ({
+              option({ label, value, active }) {
+                calledValues.push(value);
+                return new Option(label, value, false, active);
+              },
+            }),
+          });
+          expect(choices.getValue(true)).to.equal('Option 2 value');
+          expect(select.value).to.equal('Option 2 value');
+          expect(select.childElementCount).to.equal(1);
+          expect(select.innerHTML).to.equal(
+            '<option value="Option 2 value">Option 2</option>',
+          );
+
+          choices.setChoiceByValue('Option 1 value');
+          expect(calledValues).to.deep.equal([
+            'Option 2 value',
+            'Option 2 value',
+            'Option 1 value',
+            'Option 1 value',
+          ]);
+        });
+      });
+
       describe('not already initialised', () => {
         let createTemplatesSpy;
         let createInputSpy;


### PR DESCRIPTION
1. This PR increases unit test coverage for `choices.js` from 38.91% to 54.69% and total coverage for statements from 55.27% to 66.62% 🎉   by testing small use case from my own practice.

2. Add global `Option` object to JSDom mocking.

PS: Something happened with this repository secrets and Codecov can't find it's token too now :-(