### PR TITLE
fix typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,7 +1856,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1893,7 +1893,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1938,7 +1938,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -2125,7 +2125,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -2712,7 +2712,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2725,7 +2725,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -3160,7 +3160,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3230,7 +3230,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -3897,7 +3897,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -5614,9 +5614,9 @@
       "dev": true
     },
     "fuse.js": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.2.tgz",
-      "integrity": "sha512-WVbrm+cAxPtyMqdtL7cYhR7aZJPhtOfjNClPya8GKMVukKDYs7pEnPINeRVX1C9WmWgU8MdYGYbUPAP2AJXdoQ=="
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.5.tgz",
+      "integrity": "sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ=="
     },
     "gauge": {
       "version": "2.7.4",
@@ -5663,7 +5663,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5828,7 +5828,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -6696,7 +6696,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -7274,7 +7274,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -7295,7 +7295,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -7538,7 +7538,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -7579,7 +7579,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -7607,7 +7607,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -7649,7 +7649,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -7831,7 +7831,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -8107,7 +8107,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -8986,7 +8986,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -9036,7 +9036,7 @@
     },
     "ora": {
       "version": "0.2.3",
-      "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
@@ -9087,7 +9087,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -9323,7 +9323,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -11136,7 +11136,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -11500,7 +11500,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -11575,7 +11575,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -11978,7 +11978,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -11993,7 +11993,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12320,7 +12320,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "deepmerge": "^4.2.0",
-    "fuse.js": "3.4.2",
+    "fuse.js": "^3.4.5",
     "redux": "^4.0.4"
   },
   "npmName": "choices.js",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,12 +4,16 @@
 // Definitions: https://github.com/jshjohnson/Choices
 // TypeScript Version: 2.9.2
 
+import { FuseOptions } from 'fuse.js';
+
 // Choices Namespace
 declare namespace Choices {
   namespace Types {
     type renderSelected = 'auto' | 'always';
     type dropdownPosition = 'auto' | 'top';
-    type strToEl = (str: string) => HTMLElement | HTMLInputElement | HTMLOptionElement;
+    type strToEl = (
+      str: string
+    ) => HTMLElement | HTMLInputElement | HTMLOptionElement;
     type stringFunction = () => string;
     type noticeStringFunction = (value: string) => string;
     type noticeLimitFunction = (maxItemCount: number) => string;
@@ -17,16 +21,16 @@ declare namespace Choices {
   }
 
   interface Choice {
-    customProperties?: { [prop: string]: any };
+    customProperties?: Record<sting, any>;
     disabled?: boolean;
     elementId?: string;
     groupId?: string;
     id?: string;
     keyCode?: number;
     label: string;
-    placeholder?: any;
+    placeholder?: boolean;
     selected?: boolean;
-    value: any;
+    value: string;
   }
 
   /**
@@ -40,16 +44,7 @@ declare namespace Choices {
      *
      * Arguments: id, value, label, groupValue, keyCode
      */
-    "addItem": CustomEvent;
-
-    /**
-     * A filter that will need to pass for a user to successfully add an item.
-     *
-     * **Input types affected:** text
-     *
-     * @default null
-     */
-    addItemFilterFn?: () => any;
+    addItem: CustomEvent;
 
     /**
      * Triggered each time an item is removed (programmatically or by the user).
@@ -58,7 +53,7 @@ declare namespace Choices {
      *
      * Arguments: id, value, label, groupValue
      */
-    "removeItem": CustomEvent;
+    removeItem: CustomEvent;
 
     /**
      * Triggered each time an item is highlighted.
@@ -67,7 +62,7 @@ declare namespace Choices {
      *
      * Arguments: id, value, label, groupValue
      */
-    "highlightItem": CustomEvent;
+    highlightItem: CustomEvent;
 
     /**
      * Triggered each time an item is unhighlighted.
@@ -76,7 +71,7 @@ declare namespace Choices {
      *
      * Arguments: id, value, label, groupValue
      */
-    "unhighlightItem": CustomEvent;
+    unhighlightItem: CustomEvent;
 
     /**
      * Triggered each time a choice is selected **by a user**, regardless if it changes the value of the input.
@@ -85,7 +80,7 @@ declare namespace Choices {
      *
      * Arguments: value, keyCode
      */
-    "choice": CustomEvent;
+    choice: CustomEvent;
 
     /**
      * Triggered each time an item is added/removed **by a user**.
@@ -94,7 +89,7 @@ declare namespace Choices {
      *
      * Arguments: value
      */
-    "change": CustomEvent;
+    change: CustomEvent;
 
     /**
      * Triggered when a user types into an input to search choices.
@@ -103,7 +98,7 @@ declare namespace Choices {
      *
      * Arguments: value, resultCount
      */
-    "search": CustomEvent;
+    search: CustomEvent;
 
     /**
      * Triggered when the dropdown is shown.
@@ -112,7 +107,7 @@ declare namespace Choices {
      *
      * Arguments: -
      */
-    "showDropdown": CustomEvent;
+    showDropdown: CustomEvent;
 
     /**
      * Triggered when the dropdown is hidden.
@@ -121,7 +116,7 @@ declare namespace Choices {
      *
      * Arguments: -
      */
-    "hideDropdown": CustomEvent;
+    hideDropdown: CustomEvent;
   }
 
   interface Group {
@@ -131,30 +126,34 @@ declare namespace Choices {
     value: any;
   }
 
-  interface Item {
+  interface Item extends Choice {
     choiceId?: string;
-    customProperties?: { [prop: string]: any };
-    groupId?: string;
-    id?: string;
     keyCode?: number;
-    label: string;
-    placeholder?: string;
-    value: any;
   }
 
   interface Templates {
     containerOuter?: (classNames: ClassNames, direction: string) => HTMLElement;
     containerInner?: (classNames: ClassNames) => HTMLElement;
-    itemList?: (classNames: ClassNames, isSelectOneElement: boolean) => HTMLElement;
+    itemList?: (
+      classNames: ClassNames,
+      isSelectOneElement: boolean
+    ) => HTMLElement;
     placeholder?: (classNames: ClassNames, value: string) => HTMLElement;
-    item?: (classNames: ClassNames, data: any, removeItemButton: boolean) => HTMLElement;
-    choiceList?: (classNames: ClassNames, isSelectOneElement: boolean) => HTMLElement;
-    choiceGroup?: (classNames: ClassNames, data: any) => HTMLElement;
-    choice?: (classNames: ClassNames, data: any) => HTMLElement;
+    item?: (
+      classNames: ClassNames,
+      data: Choice,
+      removeItemButton: boolean
+    ) => HTMLElement;
+    choiceList?: (
+      classNames: ClassNames,
+      isSelectOneElement: boolean
+    ) => HTMLElement;
+    choiceGroup?: (classNames: ClassNames, data: Choice) => HTMLElement;
+    choice?: (classNames: ClassNames, data: Choice) => HTMLElement;
     input?: (classNames: ClassNames) => HTMLInputElement;
     dropdown?: (classNames: ClassNames) => HTMLElement;
     notice?: (classNames: ClassNames, label: string) => HTMLElement;
-    option?: (data: any) => HTMLOptionElement;
+    option?: (data: Choice) => HTMLOptionElement;
   }
 
   /** Classes added to HTML generated by Choices. By default classnames follow the BEM notation. */
@@ -214,9 +213,19 @@ declare namespace Choices {
   }
 
   interface passedElement {
-    classNames: Choices.ClassNames,
-    element: HTMLElement,
-    isDisabled: boolean,
+    classNames: Choices.ClassNames;
+    element: (HTMLInputElement | HTMLSelectElement) & {
+      // Extends HTMLElement addEventListener with Choices events
+      addEventListener<K extends keyof Choices.EventMap>(
+        type: K,
+        listener: (
+          this: HTMLInputElement | HTMLSelectElement,
+          ev: Choices.EventMap[K]
+        ) => void,
+        options?: boolean | AddEventListenerOptions
+      ): void;
+    };
+    isDisabled: boolean;
     parentInstance: Choices;
   }
 
@@ -225,7 +234,7 @@ declare namespace Choices {
    *
    * **Terminology**
    *
-   * - **Choice:** A choice is a value a user can select. A choice would be equivelant to the `<option></option>` element within a select input.
+   * - **Choice:** A choice is a value a user can select. A choice would be equivalent to the `<option></option>` element within a select input.
    * - **Group:** A group is a collection of choices. A group should be seen as equivalent to a `<optgroup></optgroup>` element within a select input.
    * - **Item:** An item is an inputted value **_(text input)_** or a selected choice **_(select element)_**. In the context of a select element, an item is equivelent to a selected option element: `<option value="Hello" selected></option>` whereas in the context of a text input an item is equivelant to `<input type="text" value="Hello">`
    */
@@ -268,7 +277,7 @@ declare namespace Choices {
      *
      * @default []
      */
-    items?: any[];
+    items?: string[] | Choice[];
 
     /**
      * Add choices (see terminology) to select input.
@@ -297,7 +306,7 @@ declare namespace Choices {
      *
      * @default []
      */
-    choices?: any[];
+    choices?: Choice[];
 
     /**
      * The amount of choices to be rendered within the dropdown list `("-1" indicates no limit)`. This is useful if you have a lot of choices where it is easier for a user to use the search area to find a choice.
@@ -325,6 +334,27 @@ declare namespace Choices {
      * @default true
      */
     addItems?: boolean;
+
+    /**
+     * A filter that will need to pass for a user to successfully add an item.
+     *
+     * **Input types affected:** text
+     *
+     * @default null
+     */
+    addItemFilterFn?: (value: string) => boolean;
+
+    /**
+     * The text that is shown when a user has inputted a new item but has not pressed the enter key. To access the current input value, pass a function with a `value` argument (see the **default config** [https://github.com/jshjohnson/Choices#setup] for an example), otherwise pass a string.
+     *
+     * **Input types affected:** text
+     *
+     * @default
+     * ```
+     * (value) => `Press Enter to add <b>"${value}"</b>`;
+     * ```
+     */
+    addItemText?: string | Choices.Types.noticeStringFunction;
 
     /**
      * Whether a user can remove items.
@@ -363,7 +393,7 @@ declare namespace Choices {
     duplicateItemsAllowed?: boolean;
 
     /**
-     * What divides each value. The default delimiter seperates each value with a comma: `"Value 1, Value 2, Value 3"`.
+     * What divides each value. The default delimiter separates each value with a comma: `"Value 1, Value 2, Value 3"`.
      *
      * **Input types affected:** text
      *
@@ -480,7 +510,7 @@ declare namespace Choices {
      *
      * @default sortByAlpha
      */
-    sortFilter?: (current: any, next: any) => number;
+    sortFilter?: (current: Choice, next: Choice) => number;
 
     /**
      * Whether the input should show a placeholder. Used in conjunction with `placeholderValue`. If `placeholder` is set to true and no value is passed to `placeholderValue`, the passed input's placeholder attribute will be used as the placeholder value.
@@ -583,18 +613,6 @@ declare namespace Choices {
     itemSelectText?: string;
 
     /**
-     * The text that is shown when a user has inputted a new item but has not pressed the enter key. To access the current input value, pass a function with a `value` argument (see the **default config** [https://github.com/jshjohnson/Choices#setup] for an example), otherwise pass a string.
-     *
-     * **Input types affected:** text
-     *
-     * @default
-     * ```
-     * (value) => `Press Enter to add <b>"${value}"</b>`;
-     * ```
-     */
-    addItemText?: string | Choices.Types.noticeStringFunction;
-
-    /**
      * The text that is shown when a user has focus on the input but has already reached the **max item count** [https://github.com/jshjohnson/Choices#maxitemcount]. To access the max item count, pass a function with a `maxItemCount` argument (see the **default config** [https://github.com/jshjohnson/Choices#setup] for an example), otherwise pass a string.
      *
      * **Input types affected:** text
@@ -623,13 +641,7 @@ declare namespace Choices {
     /**
      * Choices uses the great Fuse library for searching. You can find more options here: https://github.com/krisk/Fuse#options
      */
-    fuseOptions?: {
-      [index: string]: any;
-      /**
-       * @default 'score'
-       */
-      include?: string;
-    };
+    fuseOptions?: FuseOptions;
 
     /**
      * Function to run once Choices initialises.
@@ -640,7 +652,7 @@ declare namespace Choices {
      *
      * @default null
      */
-    callbackOnInit?: () => any;
+    callbackOnInit?: (this: Choices) => void;
 
     /**
      * Function to run on template creation. Through this callback it is possible to provide custom templates for the various components of Choices (see terminology). For Choices to work with custom templates, it is important you maintain the various data attributes defined here [https://github.com/jshjohnson/Choices/blob/67f29c286aa21d88847adfcd6304dc7d068dc01f/assets/scripts/src/choices.js#L1993-L2067].
@@ -680,22 +692,13 @@ declare namespace Choices {
   }
 }
 
-// Overload HTMLElement addEventListener with Choices events
-interface HTMLElement {
-  addEventListener<K extends keyof Choices.EventMap>(type: K, listener: (this: HTMLElement, ev: Choices.EventMap[K]) => any, useCapture?: boolean): void;
-}
-
 // Exporting default class
 export default class Choices {
   idNames: any;
   config: Choices.Options;
 
   // State Tracking
-  store: any;
   initialised: boolean;
-  currentState: any;
-  prevState: any;
-  currentValue: string;
 
   // Element
   passedElement: Choices.passedElement;
@@ -720,8 +723,10 @@ export default class Choices {
 
   wasTap: boolean;
 
-  constructor(element: string | HTMLElement | HTMLCollectionOf<Element> | NodeList, userConfig?: Choices.Options);
-  new(element?: string | HTMLElement | HTMLCollectionOf<Element> | NodeList, userConfig?: Choices.Options): this;
+  constructor(
+    element: string | HTMLInputElement | HTMLSelectElement,
+    userConfig?: Choices.Options
+  );
 
   /**
    * Creates a new instance of Choices, adds event listeners, creates templates and renders a Choices element to the DOM.
@@ -779,7 +784,6 @@ export default class Choices {
    * **Input types affected:** text, select-multiple
    */
   removeHighlightedItems(runEvent?: boolean): this;
-
 
   /**
    * Show option list dropdown (only affects select inputs).
@@ -880,7 +884,12 @@ export default class Choices {
   setChoiceByValue(value: string | string[]): this;
 
   /** Direct populate choices */
-  setChoices(choices: Choices.Choice[], value: string, label: string, replaceChoices?: boolean): this;
+  setChoices(
+    choices: Choices.Choice[],
+    value: string,
+    label: string,
+    replaceChoices?: boolean
+  ): this;
 
   /**
    * Removes all items, choices and groups. Use with caution.
@@ -935,13 +944,24 @@ export default class Choices {
   ajax(fn: (values: any) => any): this;
 
   /** Render group choices into a DOM fragment and append to choice list */
-  private createGroupsFragment(groups: Choices.Group[], choices: Choices.Choice[], fragment: DocumentFragment): DocumentFragment;
+  private createGroupsFragment(
+    groups: Choices.Group[],
+    choices: Choices.Choice[],
+    fragment: DocumentFragment
+  ): DocumentFragment;
 
   /** Render choices into a DOM fragment and append to choice list */
-  private createChoicesFragment(choices: Choices.Choice[], fragment: DocumentFragment, withinGroup?: boolean): DocumentFragment;
+  private createChoicesFragment(
+    choices: Choices.Choice[],
+    fragment: DocumentFragment,
+    withinGroup?: boolean
+  ): DocumentFragment;
 
   /** Render items into a DOM fragment and append to items list */
-  private _createItemsFragment(items: Choices.Item[], fragment?: DocumentFragment): void;
+  private _createItemsFragment(
+    items: Choices.Item[],
+    fragment?: DocumentFragment
+  ): void;
 
   /** Render DOM with values */
   private render(): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -724,7 +724,11 @@ export default class Choices {
   wasTap: boolean;
 
   constructor(
-    element: string | HTMLInputElement | HTMLSelectElement,
+    element:
+      | string
+      | HTMLInputElement
+      | HTMLSelectElement
+      | Array<string | HTMLInputElement | HTMLSelectElement>,
     userConfig?: Choices.Options
   );
 


### PR DESCRIPTION
Hello,

Initial motivation for this PR was fixing wrong overriding of `HTMLElement` (instead of extending) at Choices typing that resulted in following error at JavaScript checking by VSCode Typescript Intellisense:

![Screenshot 2019-10-23 at 10 14 44](https://user-images.githubusercontent.com/5350898/67411293-6711f480-f58b-11e9-9572-d4a696f98480.png)

However, on the way fixed/improved several more things, mostly related to the use of `any` and fact that Choices is not expecting _any_ HTMLElement, but only either `HTMLInputElement` or `HTMLSelectElement`.

Upgraded fuse.js to the latest version due to fix in their typings. This also decreases bundle size, but I'm not sure that I must submit rebuilded assets as part of this PR.