### PR TITLE
remove redundant CSS

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -822,7 +822,7 @@ class Choices {
     }
 
     // If we are clicking on an option
-    const id = element.getAttribute('data-id');
+    const { id } = element.dataset;
     const choice = this._store.getChoiceById(id);
     if (!choice) return;
     const passedKeyCode =

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -856,7 +856,7 @@ class Choices {
 
     this.clearInput();
 
-    // We wont to close the dropdown if we are dealing with a single select box
+    // We want to close the dropdown if we are dealing with a single select box
     if (hasActiveDropdown && this._isSelectOneElement) {
       this.hideDropdown(true);
       this.containerOuter.focus();

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -824,6 +824,7 @@ class Choices {
     // If we are clicking on an option
     const id = element.getAttribute('data-id');
     const choice = this._store.getChoiceById(id);
+    if (!choice) return;
     const passedKeyCode =
       activeItems[0] && activeItems[0].keyCode ? activeItems[0].keyCode : null;
     const hasActiveDropdown = this.dropdown.isActive;
@@ -835,7 +836,7 @@ class Choices {
       choice,
     });
 
-    if (choice && !choice.selected && !choice.disabled) {
+    if (!choice.selected && !choice.disabled) {
       const canAddItem = this._canAddItem(activeItems, choice.value);
 
       if (canAddItem.response) {

--- a/src/scripts/store/store.js
+++ b/src/scripts/store/store.js
@@ -139,11 +139,13 @@ export default class Store {
 
   /**
    * Get single choice by it's ID
-   * @return {Object} Found choice
+   * @param {id} string
+   * @return {import('../../../types/index').Choices.Choice | false} Found choice
    */
   getChoiceById(id) {
     if (id) {
-      return this.activeChoices.find(choice => choice.id === parseInt(id, 10));
+      const n = parseInt(id, 10);
+      return this.activeChoices.find(choice => choice.id === n);
     }
     return false;
   }

--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -343,12 +343,4 @@ $choices-icon-cross-inverse: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEiI
   opacity: 0.5;
 }
 
-.#{$choices-selector}__input[hidden],
-.#{$choices-selector}[data-type*='select-one']
-  .#{$choices-selector}__input[hidden],
-.#{$choices-selector}[data-type*='select-multiple']
-  .#{$choices-selector}__input[hidden] {
-  display: none;
-}
-
 /*=====  End of Choices  ======*/


### PR DESCRIPTION
Removing leftovers of #691 - that elements are already hidden by `hidden` attribute.

Not sure how the fix in JS are related here (but it was a bug anyway), but without these changes tests are breaking.