### PR TITLE
[FIX] make `hidden` important

### DIFF
--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -43,6 +43,10 @@ $choices-icon-cross-inverse: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEiI
       cursor: not-allowed;
     }
   }
+
+  [hidden] {
+    display: none !important;
+  }
 }
 
 .#{$choices-selector}[data-type*='select-one'] {


### PR DESCRIPTION
Sorry, it's a recovery for #691. `[hidden]` is [very weak](https://css-tricks.com/the-hidden-attribute-is-visibly-weak/), so, need to give it some additional power.