### PR TITLE
[Tooling] VSCode Debug configurations and project settings

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  singleQuote: true,
-  trailingComma: "all"
-}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,13 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": ["*.svg"],
+      "options": {
+        "parser": "html",
+        "htmlWhitespaceSensitivity": "ignore"
+      }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,5 +10,8 @@
     "github.vscode-pull-request-github",
     // needed for our configured debug configuration with Chrome
     "msjsdiag.debugger-for-chrome"
+    // Mocha recommended - https://mochajs.org/#mocha-sidebar-vs-code,
+    // but it's buggy
+    // "maty.vscode-mocha-sidebar"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,12 +2,13 @@
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
     // we enforce ESLint rules, so, recommend extension
     "dbaeumer.vscode-eslint",
     // we use prettier, so, recommend extension
     "esbenp.prettier-vscode",
     // we are on GitHub, so, recommend extension
-    "github.vscode-pull-request-github"
+    "github.vscode-pull-request-github",
+    // needed for our configured debug configuration with Chrome
+    "msjsdiag.debugger-for-chrome"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,77 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome",
+      "preLaunchTask": "buildAndWatch",
+      "url": "http://localhost:3001",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "webpack://Choices/*": "${workspaceFolder}/*"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["-u", "tdd", "--timeout", "999999", "--colors", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "openOnSessionStart",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-u",
+        "tdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "openOnSessionStart",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Cypress Current File",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/./bin/cypress",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}\\node_modules\\.bin\\cypress.cmd"
+      },
+      "runtimeArgs": [
+        "run",
+        "--headed",
+        "--no-exit",
+        "--browser=electron",
+        "--port",
+        "9898",
+        "--spec"
+      ],
+      "protocol": "legacy",
+      "port": 9898,
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "preLaunchTask": "buildAndWatch",
+      "internalConsoleOptions": "openOnSessionStart",
+      "timeout": 999999999999999,
+      "autoAttachChildProcesses": false,
+      "env": {
+        "NODE_ENV": "test"
+        // "DEBUG": "cypress:*"
+      }
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,7 @@
       "type": "node",
       "request": "launch",
       "name": "Cypress Current File",
-      "runtimeExecutable": "${workspaceFolder}/node_modules/./bin/cypress",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/cypress",
       "windows": {
         "runtimeExecutable": "${workspaceFolder}\\node_modules\\.bin\\cypress.cmd"
       },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,10 +16,10 @@
       "type": "node",
       "request": "launch",
       "name": "Mocha Current File",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": ["-u", "tdd", "--timeout", "999999", "--colors", "${file}"],
+      "program": "${workspaceFolder}/node_modules/mocha/bin/mocha",
+      "args": ["-u", "bdd", "--timeout", "999999", "--colors", "${file}"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "openOnSessionStart",
+      "internalConsoleOptions": "neverOpen",
       "env": {
         "NODE_ENV": "test"
       }
@@ -29,14 +29,7 @@
       "request": "launch",
       "name": "Mocha All",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "-u",
-        "tdd",
-        "--timeout",
-        "999999",
-        "--colors",
-        "${workspaceFolder}/test"
-      ],
+      "args": ["-u", "bdd", "--timeout", "999999", "--colors"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "openOnSessionStart",
       "env": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,14 +27,13 @@
   },
   "mocha.files.glob": "src/scripts/**/*.test.js",
   "mocha.requires": ["@babel/register", "./config/jsdom.js"],
-
   // for Windows collaborators
   "files.eol": "\n",
   "files.encoding": "utf8",
   // associations for some files this project is using
   "files.associations": {
     ".browserslistrc": "gitignore",
-    ".huskyrc": "json",
+    ".huskyrc": "jsonc",
     ".npmrc": "ini"
   },
   // We use NPM as package manager
@@ -55,7 +54,7 @@
     },
     // Prettier config
     {
-      "fileMatch": [".prettierrc.js"],
+      "fileMatch": [".prettierrc.json"],
       "url": "http://json.schemastore.org/prettierrc"
     }
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,55 @@
 {
   "eslint.enable": true,
+  // prevent watch task failures on lint errors
+  "eslint.autoFixOnSave": true,
+  "editor.formatOnSave": true,
+  // switch off default VSCode formatting rules
+  "javascript.format.enable": false,
   // Javascript prettier runs via ESLint
-  "prettier.disableLanguages": ["javascript"]
+  "prettier.disableLanguages": ["javascript"],
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "public/assets": true,
+    "**/coverage": true
+  },
+  // for Windows collaborators
+  "files.eol": "\n",
+  "files.encoding": "utf8",
+  // associations for some files this project is using
+  "files.associations": {
+    ".browserslistrc": "gitignore",
+    ".huskyrc": "json",
+    ".npmrc": "ini"
+  },
+  // We use NPM as package manager
+  "npm.packageManager": "npm",
+  "npm.autoDetect": "on",
+  "npm.fetchOnlinePackageInfo": true,
+  "eslint.packageManager": "npm",
+  "json.schemas": [
+    // Cypress related settings - https://docs.cypress.io/guides/tooling/intelligent-code-completion.html#Features-1
+    {
+      "fileMatch": ["cypress.json"],
+      "url": "https://on.cypress.io/cypress.schema.json"
+    },
+    // Husky config file
+    {
+      "fileMatch": [".huskyrc"],
+      "url": "http://json.schemastore.org/huskyrc"
+    },
+    // Prettier config
+    {
+      "fileMatch": [".prettierrc.js"],
+      "url": "http://json.schemastore.org/prettierrc"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,13 @@
     "public/assets": true,
     "**/coverage": true
   },
+  // Mocha Sidebar settings
+  "mocha.env": {
+    "NODE_ENV": "test"
+  },
+  "mocha.files.glob": "src/scripts/**/*.test.js",
+  "mocha.requires": ["@babel/register", "./config/jsdom.js"],
+
   // for Windows collaborators
   "files.eol": "\n",
   "files.encoding": "utf8",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,10 @@
       "type": "npm",
       "label": "buildAndWatch",
       "script": "js:watch",
-      "group": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
       "isBackground": true,
       "presentation": {
         "echo": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,84 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "label": "buildAndWatch",
+      "script": "js:watch",
+      "group": "build",
+      "isBackground": true,
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": [
+        "$eslint-stylish",
+        {
+          "owner": "webpack",
+          "fileLocation": "absolute",
+          "pattern": [
+            {
+              "regexp": "^Module build failed \\(from (\\.+)\\)",
+              "file": 1,
+              "line": 2,
+              "column": 3
+            },
+            {
+              "regexp": "\\s*TS\\d+:\\s*(.*)",
+              "message": 1
+            }
+          ],
+          "severity": "error",
+          "source": "webpack",
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": "^Listening at",
+            "endsPattern": "Compiled successfully\\."
+          }
+        }
+      ]
+    },
+    {
+      "type": "npm",
+      "script": "css:build",
+      "group": "build",
+      "problemMatcher": ["$node-sass"]
+    },
+    {
+      "type": "npm",
+      "script": "lint",
+      "problemMatcher": ["$eslint-stylish"]
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "group": "build"
+    },
+    {
+      "type": "npm",
+      "script": "test",
+      "group": "test"
+    },
+    {
+      "type": "npm",
+      "script": "test:e2e",
+      "group": "test"
+    },
+    {
+      "type": "npm",
+      "script": "test:unit",
+      "group": "test"
+    },
+    {
+      "type": "npm",
+      "script": "cypress:open",
+      "isBackground": true
+    }
+  ]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,9 +1,15 @@
 {
   "compilerOptions": {
-    "strict": true,
-    "baseUrl": "../node_modules",
+    "checkJs": true,
     "target": "es2020",
-    "lib": ["es5", "dom"],
-    "types": ["cypress"]
+    "lib": ["esnext", "dom"],
+    "types": ["cypress"],
+    "strict": true,
+    /* Additional Checks */
+    "noImplicitAny": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   }
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,16 +5,17 @@ const baseConfig = require('./webpack.config.base');
 
 module.exports = deepMerge(
   baseConfig,
-  {
+  /** @type {import('webpack').Configuration} */ ({
     mode: 'development',
     output: {
       path: path.resolve(__dirname, './public'),
       filename: 'choices.min.js',
       publicPath: 'http://localhost:3001/assets/scripts/',
     },
+    devtool: 'source-map',
     entry: ['webpack/hot/dev-server', 'webpack-hot-middleware/client'],
     plugins: [new HotModuleReplacementPlugin()],
-  },
+  }),
   {
     arrayMerge(target, source) {
       return [...source, ...target];


### PR DESCRIPTION
This PR aims to make a contributor life easier by providing ready environment in VScode:

1. **Debug configurations** 
![image](https://user-images.githubusercontent.com/5350898/67625345-0133a000-f80b-11e9-8a7c-cd20b8890d38.png)
Provided ready to use debugging settings:
 - **Launch Chrome** - fires development server in background, and launches Chrome with configured source map support, so, things like breaking points works out of the box. Adjusted webpack configuration here to build source maps in development
![image](https://user-images.githubusercontent.com/5350898/67625466-9daa7200-f80c-11e9-8ecd-466756a2a1d0.png)

- **Mocha Current File** - allow to start debugging session from opened Mocha *.test.js file with all the breaking points, etc.
![Screenshot 2019-10-26 at 17 18 07](https://user-images.githubusercontent.com/5350898/67626081-a010ca00-f814-11e9-8ee9-58ffd15a5dc4.png)


- **Mocha All files** - the same, but run all suites, so, yo can start, for example, from a source file by setting a breakpoint.

- **Cypress Current File** _(that was the trickiest one 😫 )_ - from an opened `*.spec.js` fires development server (if it's not online already) and launches Cypress in headed and non-exit mode and allows to [unleash full debugging](https://docs.cypress.io/guides/guides/debugging.html)
![image](https://user-images.githubusercontent.com/5350898/67625516-30e3a780-f80d-11e9-85b0-e672f712e23c.png)

2. **Tasks** - configured tasks and problem marchers for `package.json` tasks

3. **Project settings** - added further settings to prevent Prettier and built-in formatters conflicts, improve Intellisense on some files, and enforce file formats for Window-based contributors.

4. **Adjusted `jsconfig.json`**. Most important change here is `checkJs: true` - you will start to see some annoying false positive errors from VSCode (until we will have JSDoc typing everywhere), but it helps _a lot_ with catching some hard to find errors, like this one (fixed in #694) :
![Screenshot 2019-10-26 at 17 02 37](https://user-images.githubusercontent.com/5350898/67625922-adc55000-f812-11e9-918a-560098663d00.png)

Let's do Visual Studio Code great again, try CMD + Shift + B 😄 