### PR TITLE
Remove requestAnimationFrame mock

### DIFF
--- a/config/jsdom.js
+++ b/config/jsdom.js
@@ -1,6 +1,11 @@
 const { JSDOM } = require('jsdom');
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+const jsdom = new JSDOM(
+  '<!doctype html><html><head><meta charset="utf-8"></head><body></body></html>',
+  {
+    pretendToBeVisual: true,
+  },
+);
 const { window } = jsdom;
 
 function copyProps(src, target) {
@@ -20,26 +25,6 @@ function ignoreExtensions(extensions = [], returnValue = {}) {
   });
 }
 
-function mockRAF(global) {
-  let callbacksQueue = [];
-
-  global.setInterval(() => {
-    for (let i = 0; i < callbacksQueue.length; i++) {
-      if (callbacksQueue[i] !== false) {
-        callbacksQueue[i].call(null);
-      }
-    }
-
-    callbacksQueue = [];
-  }, 1000 / 60);
-
-  global.requestAnimationFrame = callback => callbacksQueue.push(callback) - 1;
-
-  global.cancelAnimationFrame = id => {
-    callbacksQueue[id] = false;
-  };
-}
-
 global.window = window;
 global.document = window.document;
 global.navigator = {
@@ -52,9 +37,9 @@ global.Option = window.Option;
 global.HTMLOptionElement = window.HTMLOptionElement;
 global.HTMLOptGroupElement = window.HTMLOptGroupElement;
 global.DocumentFragment = window.DocumentFragment;
+global.requestAnimationFrame = window.requestAnimationFrame;
 
 copyProps(window, global);
-mockRAF(global);
 
 ignoreExtensions(['.scss', '.css']);
 ignoreExtensions(['.jpg', '.png', '.svg'], '');


### PR DESCRIPTION
`requestedAnimationFrame` is supported natively by recent versions of JSDOM with [`pretendToBeVisual`](https://github.com/jsdom/jsdom#pretending-to-be-a-visual-browser) option.