### PR TITLE
fix preventPaste

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -1825,6 +1825,7 @@ class Choices {
       element: this._getTemplate('input', this._placeholderValue),
       classNames: this.config.classNames,
       type: this.passedElement.element.type,
+      preventPaste: !this.config.paste,
     });
 
     this.choiceList = new List({

--- a/src/scripts/components/input.js
+++ b/src/scripts/components/input.js
@@ -5,18 +5,16 @@ export default class Input {
    *
    * @typedef {import('../../../types/index').Choices.passedElement} passedElement
    * @typedef {import('../../../types/index').Choices.ClassNames} ClassNames
-   * @param {{element: HTMLInputElement, type: passedElement['type'], classNames: ClassNames, placeholderValue: string, preventPaste: boolean }} p
+   * @param {{element: HTMLInputElement, type: passedElement['type'], classNames: ClassNames, preventPaste: boolean }} p
    */
-  constructor({ element, type, classNames, placeholderValue, preventPaste }) {
-    Object.assign(this, {
-      element,
-      type,
-      classNames,
-      placeholderValue,
-      preventPaste,
-    });
+  constructor({ element, type, classNames, preventPaste }) {
+    this.element = element;
+    this.type = type;
+    this.classNames = classNames;
+    this.preventPaste = preventPaste;
+
     this.isFocussed = this.element === document.activeElement;
-    this.isDisabled = false;
+    this.isDisabled = element.disabled;
     this._onPaste = this._onPaste.bind(this);
     this._onInput = this._onInput.bind(this);
     this._onFocus = this._onFocus.bind(this);
@@ -122,8 +120,7 @@ export default class Input {
   }
 
   _onPaste(event) {
-    const { target } = event;
-    if (target === this.element && this.preventPaste) {
+    if (this.preventPaste) {
       event.preventDefault();
     }
   }

--- a/src/scripts/components/input.js
+++ b/src/scripts/components/input.js
@@ -1,10 +1,20 @@
 import { sanitise } from '../lib/utils';
 
 export default class Input {
-  constructor({ element, type, classNames, placeholderValue }) {
-    Object.assign(this, { element, type, classNames, placeholderValue });
-    this.element = element;
-    this.classNames = classNames;
+  /**
+   *
+   * @typedef {import('../../../types/index').Choices.passedElement} passedElement
+   * @typedef {import('../../../types/index').Choices.ClassNames} ClassNames
+   * @param {{element: HTMLInputElement, type: passedElement['type'], classNames: ClassNames, placeholderValue: string, preventPaste: boolean }} p
+   */
+  constructor({ element, type, classNames, placeholderValue, preventPaste }) {
+    Object.assign(this, {
+      element,
+      type,
+      classNames,
+      placeholderValue,
+      preventPaste,
+    });
     this.isFocussed = this.element === document.activeElement;
     this.isDisabled = false;
     this._onPaste = this._onPaste.bind(this);


### PR DESCRIPTION
There is a reference to `Input.preventPaste` property in the Input element at [`onPaste` handler](https://github.com/jshjohnson/Choices/blob/15d54c7d342f5e44ad2ccf8a3ec5b81e56752a4c/src/scripts/components/input.js#L134). But it's not set anywhere. Is it missing functionality or some leftovers?

`classNames` also have no use in this class, do you want me to remove them? 

`placeholderValue` also is not on the call in [the only place where you creating an instance of Input](https://github.com/jshjohnson/Choices/blob/15d54c7d342f5e44ad2ccf8a3ec5b81e56752a4c/src/scripts/choices.js#L1824) element. It should either be renamed to `placeholder` and added to constructor call or (coupling with #694) removed at all. 