### PR TITLE
Resolve on save vscode conflict

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "eslint.enable": true,
   // prevent watch task failures on lint errors
   "eslint.autoFixOnSave": true,
-  "editor.formatOnSave": true,
   // switch off default VSCode formatting rules
   "javascript.format.enable": false,
   // Javascript prettier runs via ESLint
@@ -15,6 +14,9 @@
   },
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.formatOnSave": false
   },
   "search.exclude": {
     "**/node_modules": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevents a conflict between `eslint.autoFixOnSave` and `editor.formatOnSave` when saving JS files

## Motivation and Context
It was causing VSCode to format *.js files twice 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.