### PR TITLE
[Tooling] expose test upload tokens?

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,5 @@
+token: xxxxx-xxxxx-xxxxxx-xxxxxx
+
 coverage:
   parsers:
     javascript:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,10 +21,10 @@ jobs:
           HUSKY_SKIP_INSTALL: true
 
       - name: run Cypress
-        run: npx run-p --race start cypress:run
+        run: npx run-p --race start cypress:ci
         env:
           CI: true
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: XXXXXXXXXXXXXXX
           DEBUG: commit-info,cypress:server:record
           # https://docs.cypress.io/guides/guides/continuous-integration.html#Environment-variables
           COMMIT_INFO_BRANCH: ${{ github.head_ref }}


### PR DESCRIPTION
This PR hardcodes Codecov test token an Cypress record key in appropriate configurations files.

## Motivation and Context

GitHub Actions limits PR from fork repositories (i.e. any contributor that is not a repo maintainer), and so, nor `CODECOV_TOKEN` nor `CYPRESS_RECORD_KEY`.

Codecov, while allowing public repositories to not provide upload token on some CI providers, [will not include GitHub Actions](https://github.com/codecov/codecov-bash#ci-providers) in those. It's a shame to not seeing PR effect on code coverage and, on other hand I don' see how making this write only token available in configuration may hurt open source project - all information uploading to Codecov can be obtained locally by simply running tests. So, I see no risk in hard coding it here.

The same for record key of Cypress.

@jshjohnson if you agree with this proposal just checkout into this PR branch and put real values in place of xxxxxxx
