### PR TITLE
fix async setChoices flow

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -558,7 +558,9 @@ class Choices {
       }
 
       // it's a choices fetcher
-      requestAnimationFrame(() => this._handleLoadingState(true));
+      ({ then: requestAnimationFrame.bind(window) }.then(() =>
+        this._handleLoadingState(true),
+      ));
       const fetcher = choicesArrayOrFetcher(this);
       if (typeof fetcher === 'object' && typeof fetcher.then === 'function') {
         // that's a promise
@@ -569,6 +571,7 @@ class Choices {
               console.error(err);
             }
           })
+          .then(() => ({ then: requestAnimationFrame.bind(window) }))
           .then(() => this._handleLoadingState(false))
           .then(() => this);
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In async `setChoices` variant, wrap `_handleLoadingState(false)` into `requestAnimationFrame`. (variant with loadingState => true is already wrapped)

## Motivation and Context
Flow:
-> `requestAnimationFrame` -> `handleLoadingState(true)` -> insert placeholder, if needed
-> get data asynchronously
-> `handleLoadingState(false)` -> change placeholder content

So, there is a possibility, that `handleLoadingState(false)` will occur faster then `handleLoadingState(true)` (when async data request comes back very fast) So we trying to update placeholder content, when placeholder no initialized yet. (error, and hanging loading state after operation)  

## How Has This Been Tested?
Manually in browser.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.