### PR TITLE
speed up getAdjacentEl

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -1455,7 +1455,7 @@ class Choices {
       this._canSearch = false;
 
       const directionInt =
-        keyCode === downKey || keyCode === pageDownKey ? 1 : -1;
+        keyCode === downKey || keyCode === pageDownKey ? 'next' : 'previous';
       const skipKey =
         metaKey || keyCode === pageDownKey || keyCode === pageUpKey;
       const selectableChoiceIdentifier = '[data-choice-selectable]';

--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -1455,7 +1455,7 @@ class Choices {
       this._canSearch = false;
 
       const directionInt =
-        keyCode === downKey || keyCode === pageDownKey ? 'next' : 'previous';
+        keyCode === downKey || keyCode === pageDownKey ? 1 : -1;
       const skipKey =
         metaKey || keyCode === pageDownKey || keyCode === pageUpKey;
       const selectableChoiceIdentifier = '[data-choice-selectable]';

--- a/src/scripts/lib/utils.js
+++ b/src/scripts/lib/utils.js
@@ -1,16 +1,8 @@
 export const getRandomNumber = (min, max) =>
   Math.floor(Math.random() * (max - min) + min);
 
-export const generateChars = length => {
-  let chars = '';
-
-  for (let i = 0; i < length; i++) {
-    const randomChar = getRandomNumber(0, 36);
-    chars += randomChar.toString(36);
-  }
-
-  return chars;
-};
+export const generateChars = length =>
+  Array.from({ length }, () => getRandomNumber(0, 36).toString(36)).join('');
 
 export const generateId = (element, prefix) => {
   let id =
@@ -48,15 +40,15 @@ export const getAdjacentEl =
   /**
    * @param {Element} startEl
    * @param {string} selector
-   * @param {'next' | 'previous'} direction
+   * @param {1 | -1} direction
    * @returns {Element | undefined}
    */
-  (startEl, selector, direction) => {
+  (startEl, selector, direction = 1) => {
     if (!(startEl instanceof Element) || typeof selector !== 'string') {
       return undefined;
     }
 
-    const prop = `${direction}ElementSibling`;
+    const prop = `${direction > 0 ? 'next' : 'previous'}ElementSibling`;
 
     let sibling = startEl[prop];
     while (sibling) {

--- a/src/scripts/lib/utils.js
+++ b/src/scripts/lib/utils.js
@@ -44,19 +44,30 @@ export const wrap = (element, wrapper = document.createElement('div')) => {
  */
 export const findAncestorByAttrName = (el, attr) => el.closest(`[${attr}]`);
 
-export const getAdjacentEl = (startEl, className, direction = 1) => {
-  if (!startEl || !className) {
-    return;
-  }
+export const getAdjacentEl =
+  /**
+   * @param {Element} startEl
+   * @param {string} selector
+   * @param {'next' | 'previous'} direction
+   * @returns {Element | undefined}
+   */
+  (startEl, selector, direction) => {
+    if (!(startEl instanceof Element) || typeof selector !== 'string') {
+      return undefined;
+    }
 
-  const parent = startEl.parentNode.parentNode;
-  const children = Array.from(parent.querySelectorAll(className));
+    const prop = `${direction}ElementSibling`;
 
-  const startPos = children.indexOf(startEl);
-  const operatorDirection = direction > 0 ? 1 : -1;
+    let sibling = startEl[prop];
+    while (sibling) {
+      if (sibling.matches(selector)) {
+        return sibling;
+      }
+      sibling = sibling[prop];
+    }
 
-  return children[startPos + operatorDirection];
-};
+    return sibling;
+  };
 
 export const isScrolledIntoView = (el, parent, direction = 1) => {
   if (!el) {


### PR DESCRIPTION
Current implementation uses `Array.from(parentElement.querySelectorAll()).indexOf` etc. While in major amount of use cases the element we are looking for is immediately accessible by `nextElementSiblings` or `previousElementSiblings`.

Also changing parameter from a number to string for easier to understand and more error-proof code.