### PR TITLE
Indent fixed in "choices__list--dropdown"

### DIFF
--- a/src/styles/choices.scss
+++ b/src/styles/choices.scss
@@ -198,6 +198,7 @@ $choices-icon-cross-inverse: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEiI
     border: 1px solid darken($choices-primary-color, 5%);
     color: #ffffff;
     word-break: break-all;
+    box-sizing: border-box;
     &[data-deletable] {
       padding-right: 5px;
     }


### PR DESCRIPTION
Indent fixed in "choices__list--dropdown". Added "box-sizing: border-box;".

## Description
Interconnected with #749 

## Screenshots (if appropriate)
Before: https://yadi.sk/i/DUrKF9Nlet1WsA
After: https://yadi.sk/i/w_x6W8pBhTBRpA

This is with fix  [#749](https://github.com/jshjohnson/Choices/pull/749)

## Types of changes

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
