### PR TITLE
Fixed choices to fallback to options if no placeholder option is prov

### DIFF
--- a/src/scripts/choices.js
+++ b/src/scripts/choices.js
@@ -2267,7 +2267,7 @@ class Choices {
   }
 
   _generatePlaceholderValue() {
-    if (this._isSelectElement) {
+    if (this._isSelectElement && this.passedElement.placeholderOption) {
       const { placeholderOption } = this.passedElement;
 
       return placeholderOption ? placeholderOption.text : false;


### PR DESCRIPTION
##  Description

Fixes #779 

Currently when you have a Choices configured for multiple, the placeholders were not working. The way to solve this is to just simply add a placeholder to the input element used, which is what would normally happen, except in a Multiple select environment, adding a "default placeholder" option would actually make the choices look bad.

This fixes the problem by just falling back to the configuration placeholders if the default placeholder option is not provided.

## Screenshots (if appropriate)

![](https://api.monosnap.com/file/download?id=E1tMcrTxnkZbYMcNlYEiapzHZtjw18)

## Types of changes

This simply adds a fallback to use configuration placeholders if a default placeholder option is not found.

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
