### PR TITLE
Update passedElement.value after removing item

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1227,6 +1227,8 @@ class Choices {
     this._store.withTxn(() => {
       // Remove item associated with button
       this._removeItem(itemToRemove);
+      const passedElementValueModified = this.passedElement.value.split(",").filter(x=> x !== itemToRemove.value)
+      this.passedElement.value = passedElementValueModified.join(",")
       this._triggerChange(itemToRemove.value);
 
       if (this._isSelectOneElement && !this._hasNonChoicePlaceholder) {


### PR DESCRIPTION
## Description

the problem arose because of the wrapper this._store.withTxn(function () {}). I compared the working version of 10 choices and 11 (with this bug) and here is the problem. See the screenshots below.
![image](https://github.com/user-attachments/assets/6f93dc2a-c5d8-4cb3-bbdc-23a78a17a4df)
When we click on the 'X' to remove the "Second" tag, we get, for version 11 (with bug):
![image](https://github.com/user-attachments/assets/e395ea04-28b3-4a44-9833-0c9cb09d1fe3)
As you can see, after deleting item, the passedElement.value field does not change its value (second is not deleted)

Compare this to working version 10:
![image](https://github.com/user-attachments/assets/b204de9d-dafd-4b75-ae02-94d54816a5d6)
As you see after removal "second" passedElement.value changed and contains only "first" value.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
