### PR TITLE
updated documentation for the callbackOnCreateTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ const example = new Choices(element, {
   callbackOnCreateTemplates: function(strToEl, escapeForTemplate, getClassNames) {
     return {
       item: ({ classNames }, data) => {
-        return template(`
+        return strToEl(`
           <div class="${getClassNames(classNames.item).join(' ')} ${
           getClassNames(data.highlighted
             ? classNames.highlightedState
@@ -856,7 +856,7 @@ const example = new Choices(element, {
         `);
       },
       choice: ({ classNames }, data) => {
-        return template(`
+        return strToEl(`
           <div class="${getClassNames(classNames.item).join(' ')} ${getClassNames(classNames.itemChoice).join(' ')} ${
           getClassNames(data.disabled ? classNames.itemDisabled : classNames.itemSelectable).join(' ')
         }" data-select-text="${this.config.itemSelectText}" data-choice ${


### PR DESCRIPTION
## Description

The documentation for callbackOnCreateTemplate was referencing a non existent function called `template` it should be `strToEl` as that is the intended return type for changing a template. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
