### PR TITLE
Soften constraints on remove buttons

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1210,7 +1210,7 @@ class Choices {
       return;
     }
 
-    const id = element && parseDataSetId(element.parentElement);
+    const id = element && parseDataSetId(element.closest('[data-id]');
     const itemToRemove = id && items.find((item) => item.id === id);
     if (!itemToRemove) {
       return;


### PR DESCRIPTION
## Description

This is a proposal to soften the constraints on remove buttons content and placement. As Choices allows to use custom templates for each of its components, the two small changes suggested here offer more possibilities to users.

1. Allows SVG elements to be clicked  
   The first lines of the `_onMouseDown` method exclude any event without an `HTMLElement` as target. Replacing `HTMLElement` with `Element` allows `SVGElement`s to be used (for SVG icons, for example)
2. Allows remove buttons to not be direct descendant of an item  
   In `_handleButtonAction`, because item id is only looked for on `element.parentElement`, remove buttons currently have to be direct descendant of their parent item. Using `closest` and a data-attribute selector (just like in `_onMouseDown`) opens the door to more complex HTML structures for items. 

## Types of changes

- [ ] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x ] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

As changes are related to undocumented limitations I discovered while working with Choices, there should be no documentation to update. I could not find appropriate unit tests to amend but I would be happy to add some if you think it's useful.