### PR TITLE
Match the previous height of the choices docs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,7 @@
     <div class="container">
       <div class="section">
         <a href="https://github.com/jshjohnson/Choices" class="logo">
-          <picture>
+          <picture style="display: flex">
             <source media="(prefers-color-scheme: dark)" srcset="assets/images/logo--dark.svg" class="logo-img source-dark">
             <source media="(prefers-color-scheme: light)" srcset="assets/images/logo.svg" class="logo-img source-light">
             <img src="assets/images/logo.svg" alt="Choices.js logo" class="logo-img">


### PR DESCRIPTION
## Description

Kinda realized this last minute why the tests would have failed and checked the previous diffs. It is due to introducing a darkmode logo and the padding not being reset. Using `display: flex` on the picture restores the previous behavior.

No need to do anything, I'll wait for the screenshots, check and then update them accordingly 😊 (Thanks for telling me how)

## Screenshots (if appropriate)

<img width="558" height="214" alt="image" src="https://github.com/user-attachments/assets/fed235b9-8b6c-4db4-8220-c8ad7a601570" />

<img width="623" height="228" alt="image" src="https://github.com/user-attachments/assets/38eb1703-b614-4d7b-8f82-42a33c34654c" />



## Types of changes

- [x] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
