### PR TITLE
Fix data-label-description from source html was not treated as trusted

### DIFF
--- a/src/scripts/components/wrapped-select.ts
+++ b/src/scripts/components/wrapped-select.ts
@@ -94,7 +94,9 @@ export default class WrappedSelect extends WrappedElement<HTMLSelectElement> {
       labelClass:
         typeof option.dataset.labelClass !== 'undefined' ? stringToHtmlClass(option.dataset.labelClass) : undefined,
       labelDescription:
-        typeof option.dataset.labelDescription !== 'undefined' ? option.dataset.labelDescription : undefined,
+        typeof option.dataset.labelDescription !== 'undefined'
+          ? { trusted: option.dataset.labelDescription }
+          : undefined,
       customProperties: parseCustomProperties(option.dataset.customProperties),
     };
   }

--- a/src/scripts/interfaces/choice-full.ts
+++ b/src/scripts/interfaces/choice-full.ts
@@ -1,4 +1,5 @@
 import { StringUntrusted } from './string-untrusted';
+import { StringPreEscaped } from './string-pre-escaped';
 import { Types } from './types';
 // eslint-disable-next-line import/no-cycle
 import { GroupFull } from './group-full';
@@ -15,7 +16,7 @@ export interface ChoiceFull {
   itemEl?: HTMLElement;
   choiceEl?: HTMLElement;
   labelClass?: Array<string>;
-  labelDescription?: string;
+  labelDescription?: StringPreEscaped | StringUntrusted | string;
   customProperties?: Types.CustomProperties;
   disabled: boolean;
   active: boolean;

--- a/src/scripts/interfaces/input-choice.ts
+++ b/src/scripts/interfaces/input-choice.ts
@@ -1,4 +1,5 @@
 import { StringUntrusted } from './string-untrusted';
+import { StringPreEscaped } from './string-pre-escaped';
 // eslint-disable-next-line
 import { Types } from './types';
 
@@ -6,7 +7,7 @@ export interface InputChoice {
   id?: number;
   highlighted?: boolean;
   labelClass?: string | Array<string>;
-  labelDescription?: string;
+  labelDescription?: StringPreEscaped | StringUntrusted | string;
   customProperties?: Types.CustomProperties;
   disabled?: boolean;
   active?: boolean;

--- a/src/scripts/lib/utils.ts
+++ b/src/scripts/lib/utils.ts
@@ -135,7 +135,7 @@ export const getChoiceForOutput = (choice: ChoiceFull, keyCode?: number): EventC
     id: choice.id,
     highlighted: choice.highlighted,
     labelClass: choice.labelClass,
-    labelDescription: choice.labelDescription,
+    labelDescription: unwrapStringForRaw(choice.labelDescription),
     customProperties: choice.customProperties,
     disabled: choice.disabled,
     active: choice.active,

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -41,7 +41,7 @@ const assignCustomProperties = (el: HTMLElement, choice: ChoiceFull, withCustomP
   }
 
   if (labelDescription) {
-    dataset.labelDescription = labelDescription;
+    dataset.labelDescription = unwrapStringForRaw(labelDescription);
   }
 
   if (withCustomProperties && customProperties) {


### PR DESCRIPTION
Allows `Choice.labelDescription` to be `StringPreEscaped | StringUntrusted | string | undefined` not just a `string | undefined`