### PR TITLE
chore(docs): make removeChoice a tertiary header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,7 +1100,7 @@ choices.disable();
 
 **Usage:** Remove each selectable item.
 
-## removeChoice(value: string);
+### removeChoice(value: string);
 
 **Input types affected:** `text`, `select-multiple`, `select-one`
 


### PR DESCRIPTION
* Add missing # to reduce it to a tertiary header

## Description

The following commit fixes the API documentation in the README such that `removeChoice()` isn't a secondary header. It looks like someone was auto-generating it or doing a search & replace and failed to catch this. The change is purely cosmetic. It doesn't do anything to touch the code and is just for my perfectionism.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (tooling change or documentation change)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added new tests for the bug I fixed/the new feature I added.
- [ ] I have modified existing tests for the bug I fixed/the new feature I added.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
