### PR TITLE
Focus input synchronously to open iOS keyboard [#1373]

### DIFF
--- a/public/test/select-one/index.html
+++ b/public/test/select-one/index.html
@@ -71,6 +71,7 @@
               const choicesBasic = new Choices('#choices-basic', {
                 allowHTML: false,
               });
+              window.choicesBasic = choicesBasic;
               document
                 .querySelector('button.disable')
                 .addEventListener('click', () => {

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -511,14 +511,14 @@ class Choices {
       preventInputFocus = !this._canSearch;
     }
 
+    if (!preventInputFocus) {
+      this.input.focus();
+    }
+
     requestAnimationFrame(() => {
       this.dropdown.show();
       const rect = this.dropdown.element.getBoundingClientRect();
       this.containerOuter.open(rect.bottom, rect.height);
-
-      if (!preventInputFocus) {
-        this.input.focus();
-      }
 
       this.passedElement.triggerEvent(EventType.showDropdown);
 

--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -511,12 +511,13 @@ class Choices {
       preventInputFocus = !this._canSearch;
     }
 
+    this.dropdown.show();
+
     if (!preventInputFocus) {
       this.input.focus();
     }
 
     requestAnimationFrame(() => {
-      this.dropdown.show();
       const rect = this.dropdown.element.getBoundingClientRect();
       this.containerOuter.open(rect.bottom, rect.height);
 
@@ -1967,8 +1968,8 @@ class Choices {
             this.input.focus();
           }
         } else {
-          this.showDropdown();
           containerOuter.element.focus();
+          this.showDropdown();
         }
       } else if (
         this._isSelectOneElement &&

--- a/test-e2e/tests/select-one.spec.ts
+++ b/test-e2e/tests/select-one.spec.ts
@@ -27,6 +27,34 @@ describe(`Choices - select one`, () => {
         });
 
         describe('click selected element', () => {
+          test('focuses the search input before deferred dropdown layout', async ({ page, bundle }) => {
+            const suite = new SelectTestSuit(page, bundle, testUrl, testId);
+            await suite.start();
+
+            const beforeFrame = await page.evaluate(() => {
+              const choices = (
+                window as unknown as {
+                  choicesBasic: {
+                    showDropdown: () => void;
+                    input: { element: HTMLInputElement };
+                    containerOuter: { element: HTMLElement };
+                  };
+                }
+              ).choicesBasic;
+              choices.showDropdown();
+
+              return {
+                inputFocused: document.activeElement === choices.input.element,
+                containerExpanded: choices.containerOuter.element.getAttribute('aria-expanded'),
+              };
+            });
+
+            expect(beforeFrame).toEqual({ inputFocused: true, containerExpanded: 'false' });
+            await expect(suite.dropdown).toBeVisible();
+            await suite.advanceClock();
+            await expect(suite.wrapper).toHaveAttribute('aria-expanded', 'true');
+          });
+
           test('toggles the dropdown', async ({ page, bundle }) => {
             const suite = new SelectTestSuit(page, bundle, testUrl, testId);
             await suite.startWithClick();

--- a/test/scripts/choices.test.ts
+++ b/test/scripts/choices.test.ts
@@ -607,6 +607,12 @@ describe('choices', () => {
           expect(output).to.deep.equal(instance);
         });
 
+        it('focuses input synchronously when input focus is allowed', () => {
+          instance.showDropdown(false);
+
+          expect(inputFocusSpy).toHaveBeenCalledOnce();
+        });
+
         it('opens containerOuter', () =>
           new Promise((done) => {
             requestAnimationFrame(() => {

--- a/test/scripts/choices.test.ts
+++ b/test/scripts/choices.test.ts
@@ -608,6 +608,7 @@ describe('choices', () => {
         });
 
         it('focuses input synchronously when input focus is allowed', () => {
+          instance.dropdown.isActive = false;
           instance.showDropdown(false);
 
           expect(inputFocusSpy).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- Fix #1373 by making the dropdown visible and focusing its search input synchronously while `showDropdown()` is still in the user-interaction path.
- Keep dropdown measurement, outer-container opening, event dispatch, and selected-choice scrolling deferred to `requestAnimationFrame`.
- Preserve `preventInputFocus` behavior.
- Add a behavior-level Playwright test that proves the input is focused before the deferred layout frame, then verifies the open state after that frame.

Fixes #1373

## Why

On affected iOS Safari and WebView versions, deferring `input.focus()` into `requestAnimationFrame` can move it outside the WebKit user-interaction context needed to show the software keyboard. Because the search input is inside the hidden dropdown, the dropdown must become visible before that synchronous focus call. The surrounding layout work can remain deferred.

## Testing

- `npm run test:unit && npm run lint:js` — passed on the exact head in a network-off clean verifier: 353 unit tests plus JavaScript lint.
- `CI=1 npx playwright test --project=chromium` — passed locally: 222 tests.
- Targeted WebKit Playwright checks for the new focus timing and the two affected paste flows — passed locally: 3 tests.
- Manual iOS-device testing was not performed.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1014:start -->
### Verification

[Northset proof-of-pass receipt M-1014](https://northset-oss.github.io/verification-pilot/receipts/M-1014/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1014:end -->
