### PR TITLE
Fix addItemFilter config option regression from v10.2.0 [Fix #1419]

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -1442,11 +1442,6 @@ class Choices {
     let canAddItem = true;
     let notice = '';
 
-    if (canAddItem && typeof config.addItemFilter === 'function' && !config.addItemFilter(value)) {
-      canAddItem = false;
-      notice = resolveNoticeFunction(config.customAddItemText, value, undefined);
-    }
-
     if (canAddItem) {
       const foundChoice = this._store.choices.find((choice) => config.valueComparer(choice.value, value));
       if (foundChoice) {
@@ -1461,6 +1456,11 @@ class Choices {
           notice = resolveNoticeFunction(config.uniqueItemText, value, undefined);
         }
       }
+    }
+
+    if (canAddItem && typeof config.addItemFilter === 'function' && !config.addItemFilter(value)) {
+      canAddItem = false;
+      notice = resolveNoticeFunction(config.customAddItemText, value, undefined);
     }
 
     if (canAddItem) {


### PR DESCRIPTION
Fix addItemFilter config option would require the callable to implementation the existing item check and duplicate item check to avoid unexpected behavior from this option.