### PR TITLE
Preserve ordering between opening the dropdown and the focus event [#1418]

### DIFF
--- a/src/scripts/choices.ts
+++ b/src/scripts/choices.ts
@@ -511,16 +511,16 @@ class Choices {
       preventInputFocus = !this._canSearch;
     }
 
+    // to ensure a virtual keyboard trigger as expected, the focus/animation must be started from the input event and not an animation frame which
     this.dropdown.show();
+    const rect = this.dropdown.element.getBoundingClientRect();
+    this.containerOuter.open(rect.bottom, rect.height);
 
     if (!preventInputFocus) {
       this.input.focus();
     }
 
     requestAnimationFrame(() => {
-      const rect = this.dropdown.element.getBoundingClientRect();
-      this.containerOuter.open(rect.bottom, rect.height);
-
       this.passedElement.triggerEvent(EventType.showDropdown);
 
       const activeElement = this.choiceList.element.querySelector<HTMLElement>(

--- a/test-e2e/tests/select-one.spec.ts
+++ b/test-e2e/tests/select-one.spec.ts
@@ -49,7 +49,7 @@ describe(`Choices - select one`, () => {
               };
             });
 
-            expect(beforeFrame).toEqual({ inputFocused: true, containerExpanded: 'false' });
+            expect(beforeFrame).toEqual({ inputFocused: true, containerExpanded: 'true' });
             await expect(suite.dropdown).toBeVisible();
             await suite.advanceClock();
             await expect(suite.wrapper).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
Fix minor regression in #1418, the `requestAnimationFrame()` is increasingly redundant but left to preserve the event occurs after the dropdown has fully shown but before it has scrolled the dropdown contents